### PR TITLE
This fixes #5 by hiding the minimized instance of quake-mode app from the overview

### DIFF
--- a/quake-mode@repsac-by.github.com/extension.js
+++ b/quake-mode@repsac-by.github.com/extension.js
@@ -13,6 +13,8 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const { getSettings } = Me.imports.util;
 const  quakemodeapp = Me.imports.quakemodeapp;
 
+const isOverviewWindow = imports.ui.workspace.Workspace.prototype._isOverviewWindow;
+
 let button, settings, quakeModeApp;
 
 function init() {
@@ -33,6 +35,11 @@ function enable() {
 		Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW | Shell.ActionMode.POPUP,
 		toggle
 	);
+
+	imports.ui.workspace.Workspace.prototype._isOverviewWindow = (win) => {
+		const show = isOverviewWindow(win);
+		return show && !(win.get_meta_window().get_gtk_application_id()+'.desktop'==app_id() && win.get_meta_window().minimized);
+	};
 }
 
 function disable() {
@@ -44,6 +51,8 @@ function disable() {
 		settings.run_dispose();
 		settings = null;
 	}
+
+	imports.ui.workspace.Workspace.prototype._isOverviewWindow = isOverviewWindow;
 }
 
 function app_id() {


### PR DESCRIPTION
One caveat is, it hides all minimized instances of the chosen app, since I couldn't find a way to distinguish between various instances. It should be okay for regular usecase since quake-mode instance would normally be the only minimized instance.

Also, it works only for GTK-based terminals like Tilix/gnome-terminal.