### PR TITLE
Adds monitor names, tray menu allowing switching between monitors

### DIFF
--- a/quake-mode@repsac-by.github.com/extension.js
+++ b/quake-mode@repsac-by.github.com/extension.js
@@ -86,6 +86,10 @@ class Indicator {
 		this.panelButton.connect('touch-event', this.onClick.bind(this))
 	}
 
+	destroy() {
+		this.panelButton.destroy();
+	}
+
 	getSettingsItem() {
 		const settingsItem = new PopupMenu.PopupMenuItem("Settings")
 		settingsItem.connect('activate', () => {openPrefs();});
@@ -142,5 +146,5 @@ function setTray(show) {
 		return;
 
 	indicator = new Indicator();
-	Main.panel.addToStatusArea(IndicatorName, this.indicator.panelButton)
+	Main.panel.addToStatusArea(IndicatorName, indicator.panelButton)
 }

--- a/quake-mode@repsac-by.github.com/extension.js
+++ b/quake-mode@repsac-by.github.com/extension.js
@@ -128,7 +128,9 @@ class Indicator {
 			});
 			menu.addMenuItem(menuItem);
 		}
-        menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+		if(monitors.length > 0) {
+			menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+		}
 		this.panelButton.menu.addMenuItem(this.getSettingsItem())
 	}
 }

--- a/quake-mode@repsac-by.github.com/prefs.js
+++ b/quake-mode@repsac-by.github.com/prefs.js
@@ -4,7 +4,6 @@
 /* global Intl */
 
 const GObject = imports.gi.GObject;
-const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 
@@ -13,7 +12,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Gettext = imports.gettext.domain(Me.uuid);
 const _ = Gettext.gettext;
 
-const { getSettings, initTranslations } = Me.imports.util;
+const { getSettings, initTranslations, getMonitors } = Me.imports.util;
 
 let settings;
 
@@ -82,21 +81,23 @@ const QuakeModePrefsWidget
 		selectMonitor.pack_start(selectMonitorRenderer, true);
 		selectMonitor.add_attribute(selectMonitorRenderer, 'text', 0);
 
-		const monitorsAvailable = Gdk.Display.get_default().get_monitors()
+		const monitors = getMonitors()
 		let monitorCurrentlySelected;
-		for(let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
-			const monitor = monitorsAvailable.get_item(idx);
+
+		for(const [idx, monitor] of monitors.entries()) {
 			const iter = monitorModel.append();
+
 			monitorModel.set(
 				iter,
 				[Columns.LABEL, Columns.VALUE],
-				[`#${idx}: ${monitor.model}`, idx]
+				[`#${idx}: ${monitor.manufacturer} ${monitor.model}`, idx]
 			)
 
 			if(idx === settings.get_int('quake-mode-monitor')) {
 				monitorCurrentlySelected = iter;
 			}
 		}
+
 		if (monitorCurrentlySelected !== undefined) {
 			selectMonitor.set_active_iter(monitorCurrentlySelected)
 		}

--- a/quake-mode@repsac-by.github.com/prefs.js
+++ b/quake-mode@repsac-by.github.com/prefs.js
@@ -73,15 +73,47 @@ const QuakeModePrefsWidget
 		this.attach(label(_('Height - %')), 0, ++r, 1, 1);
 		this.attach(spinHeight, 1, r, 1, 1);
 
-		// Height
-		const spinMonitor = new Gtk.SpinButton();
-		spinMonitor.set_range(0, Gdk.Display.get_default().get_monitors().get_n_items() - 1);
-		spinMonitor.set_increments(1, 2);
+		// Monitor Number
+		const Columns = {LABEL: 0, VALUE: 1}
+		const monitorModel = new Gtk.ListStore();
+		monitorModel.set_column_types([GObject.TYPE_STRING, GObject.TYPE_INT])
+		const selectMonitor = new Gtk.ComboBox({model: monitorModel});
+		const selectMonitorRenderer = new Gtk.CellRendererText();
+		selectMonitor.pack_start(selectMonitorRenderer, true);
+		selectMonitor.add_attribute(selectMonitorRenderer, 'text', 0);
 
-		settings.bind('quake-mode-monitor', spinMonitor, 'value', Gio.SettingsBindFlags.DEFAULT);
+		const monitorsAvailable = Gdk.Display.get_default().get_monitors()
+		let monitorCurrentlySelected;
+		for(let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
+			const monitor = monitorsAvailable.get_item(idx);
+			const iter = monitorModel.append();
+			monitorModel.set(
+				iter,
+				[Columns.LABEL, Columns.VALUE],
+				[`#${idx}: ${monitor.model}`, idx]
+			)
+
+			if(idx === settings.get_int('quake-mode-monitor')) {
+				monitorCurrentlySelected = iter;
+			}
+		}
+		if (monitorCurrentlySelected !== undefined) {
+			selectMonitor.set_active_iter(monitorCurrentlySelected)
+		}
+
+		selectMonitor.connect('changed', () => {
+			const [success, iter] = selectMonitor.get_active_iter();
+
+			if(!success) {
+				return;
+			}
+
+			const value = monitorModel.get_value(iter, Columns.VALUE)
+			settings.set_int('quake-mode-monitor', value)
+		});
 
 		this.attach(label(_('Monitor')), 0, ++r, 1, 1);
-		this.attach(spinMonitor, 1, r, 1, 1);
+		this.attach(selectMonitor, 1, r, 1, 1);
 
 		// Time
 		const spinTime = new Gtk.SpinButton({ digits: 2 });

--- a/quake-mode@repsac-by.github.com/util.js
+++ b/quake-mode@repsac-by.github.com/util.js
@@ -73,20 +73,20 @@ function getMonitors() {
 	const monitors = []
 
 	const display = Gdk.Display.get_default()
-	if(display.get_monitors) { // GDK4.4+
+	if(display && display.get_monitors) { // GDK4.4+
 		const monitorsAvailable = display.get_monitors()
 		for(let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
 			const monitor = monitorsAvailable.get_item(idx);
 
 			monitors.push(monitor)
 		}
-	} else if (display.get_n_monitors) { // GDK3.24j
+	} else if (display && display.get_n_monitors) { // GDK3.24
 		for(let idx = 0; idx < display.get_n_monitors(); idx++) {
 			const monitor = display.get_monitor(idx);
 			monitors.push(monitor)
 		}
 	} else {
-		logError(`Could not get monitor list from Display of type ${display}`)
+		log(`Could not get monitor list from Display of type ${display}`)
 	}
 
 	return monitors;

--- a/quake-mode@repsac-by.github.com/util.js
+++ b/quake-mode@repsac-by.github.com/util.js
@@ -5,6 +5,7 @@ const Gettext = imports.gettext;
 const Config = imports.misc.config;
 
 const Gio = imports.gi.Gio;
+const Gdk = imports.gi.Gdk
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
@@ -66,4 +67,27 @@ function initTranslations(domain = Me.uuid) {
 		Gettext.bindtextdomain(domain, localeDir.get_path());
 	else
 		Gettext.bindtextdomain(domain, Config.LOCALEDIR);
+}
+
+function getMonitors() {
+	const monitors = []
+
+	const display = Gdk.Display.get_default()
+	if(display.get_monitors) { // GDK4.4+
+		const monitorsAvailable = display.get_monitors()
+		for(let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
+			const monitor = monitorsAvailable.get_item(idx);
+
+			monitors.push(monitor)
+		}
+	} else if (display.get_n_monitors) { // GDK3.24j
+		for(let idx = 0; idx < display.get_n_monitors(); idx++) {
+			const monitor = display.get_monitor(idx);
+			monitors.push(monitor)
+		}
+	} else {
+		logError(`Could not get monitor list from Display of type ${display}`)
+	}
+
+	return monitors;
 }


### PR DESCRIPTION
Thanks for making this plugin!  I'd had a hacked-together solution for having a quake-mode-like terminal, and was thrilled to see that somebody had created a purpose-built plugin for this.

I happen to move my laptop around between a couple different places each having different monitor configurations.  Unfortunately, as a result, the monitor index that I'd like this to display on isn't stable.  What this does is make that easier to handle by doing two things:

1. Showing the monitor name along with its index.
2. Adds a tray menu accessible via right-clicking (left-clicking still shows the terminal) on the icon via which you can
   a. Change which monitor your terminal is displayed on.
   b. Access the extension settings.

Here are a couple screenshots to maybe explain this a little more clearly:

![image](https://user-images.githubusercontent.com/527661/153537163-307b8cd3-80e3-4ca4-948b-29fabbb80a3d.png)

![image](https://user-images.githubusercontent.com/527661/153537197-8857eef6-d05a-4157-bc0f-aee306148eeb.png)

This all seems to work great, really, and should support both Gdk 3.24 & 4.x, but I've gotta level with you about being surprised about the plugin showing different monitor names in the tray menu vs. the preferences panel on Wayland.  It seems like at least on Wayland on Gnome 20.04, maybe the extensions menu is running under XWayland?  Not super sure, but what I can say is that the reason [this](https://github.com/repsac-by/gnome-shell-extension-quake-mode/compare/master...coddingtonbear:tray_menu?expand=1#diff-752f2da8d52b1ddf8f7a4de905c11ee650046c5a57980e5a50ce4fc5869e4614R76) logic exists is that the Gdk 4.x APIs were not working when gathering the monitor list for the tray, only the 3.x ones were, and vice-versa for the preferences panel.  If you have any ideas there, I'd be delighted to hear them.