### PR TITLE
Instance per workspace

### DIFF
--- a/quake-mode@repsac-by.github.com/extension.js
+++ b/quake-mode@repsac-by.github.com/extension.js
@@ -17,7 +17,8 @@ const Me = getCurrentExtension();
 const { getSettings, getMonitors } = Me.imports.util;
 const  quakemodeapp = Me.imports.quakemodeapp;
 
-let indicator, settings, quakeModeApp;
+let indicator, settings;
+let quakeModeApps = new Map();
 
 const IndicatorName = 'Quake-mode'
 
@@ -58,11 +59,12 @@ function app_id() {
 
 async function toggle() {
 	try {
+		let currentWorkspace = global.workspace_manager.get_active_workspace();
 
-		if ( !quakeModeApp || quakeModeApp.state === quakemodeapp.state.DEAD)
-			quakeModeApp = new quakemodeapp.QuakeModeApp(app_id());
+		if ( !quakeModeApps.has(currentWorkspace) || quakeModeApps.get(currentWorkspace).state === quakemodeapp.state.DEAD)
+			quakeModeApps.set(currentWorkspace, new quakemodeapp.QuakeModeApp(app_id()));
 
-		await quakeModeApp.toggle();
+		await quakeModeApps.get(currentWorkspace).toggle();
 
 	} catch ( e ) {
 		Main.notify('Quake-mode', e.message);

--- a/quake-mode@repsac-by.github.com/quakemodeapp.js
+++ b/quake-mode@repsac-by.github.com/quakemodeapp.js
@@ -154,24 +154,18 @@ var QuakeModeApp = class {
 	first_place() {
 		const { win, actor } = this;
 
+
 		actor.set_clip(0, 0, actor.width, 0);
 
-		on(global.window_manager, 'map', (sig, wm, metaWindowActor) => {
-			if ( metaWindowActor !== actor )
-				return;
+		global.window_manager.emit('kill-window-effects', actor);
+		once(win, 'size-changed')
+			.then( () => {
+				this.state = state.RUNNING;
+				actor.remove_clip();
+				this.show();
+			} );
 
-			sig.off();
-			wm.emit('kill-window-effects', actor);
-
-			once(win, 'size-changed')
-				.then( () => {
-					this.state = state.RUNNING;
-					actor.remove_clip();
-					this.show();
-				} );
-
-			this.place();
-		});
+		this.place();
 	}
 
 	show() {

--- a/quake-mode@repsac-by.github.com/quakemodeapp.js
+++ b/quake-mode@repsac-by.github.com/quakemodeapp.js
@@ -183,6 +183,7 @@ var QuakeModeApp = class {
 		actor.translation_y = - actor.height,
 		Main.wm.skipNextEffect(actor);
 		Main.activateWindow(actor.meta_window);
+		actor.meta_window.unmaximize(3);
 
 		actor.ease({
 			translation_y: 0,

--- a/quake-mode@repsac-by.github.com/quakemodeapp.js
+++ b/quake-mode@repsac-by.github.com/quakemodeapp.js
@@ -155,7 +155,6 @@ var QuakeModeApp = class {
 		const { win, actor } = this;
 
 		actor.set_clip(0, 0, actor.width, 0);
-		win.stick();
 
 		on(global.window_manager, 'map', (sig, wm, metaWindowActor) => {
 			if ( metaWindowActor !== actor )


### PR DESCRIPTION
Closes #30

Finally I found some time to create the instance per workspace feature. (Did that for guake a while ago but then wayland and API changes came along and I ended up with this great extension).

Tested on X11 and Wayland, Gnome Shell 41.3

Now, a word of caution. I had to remove some code to get it working, waiting for a signal to be exact. I haven't had the time to figure out why this piece of code has been there in the first place. However, by removing the wait, I managed to achieve what I was looking for. Only thing remaining is that since now the very first drop-down after extension load starts in maximized window mode and the code immediately reverts the maximization, there are some fast resizings going on when you first press the hotkey. All subsequent uses of the hotkey do not have those glitches.


Maybe you guys can share some insight?