### PR TITLE
Support for Gnome 43

### DIFF
--- a/quake-mode@repsac-by.github.com/metadata.json
+++ b/quake-mode@repsac-by.github.com/metadata.json
@@ -2,7 +2,7 @@
 	"name": "quake-mode",
 	"description": "Drop-down mode for any application",
 	"uuid": "quake-mode@repsac-by.github.com",
-	"shell-version": ["41", "42"],
+	"shell-version": ["41", "42", "43"],
 	"version": 8,
 	"url": "https://github.com/repsac-by/gnome-shell-extension-quake-mode",
 	"settings-schema": "com.github.repsac-by.quake-mode",


### PR DESCRIPTION
Seems to work out-of-the-box, though closing after the first opening does not work via keyboard shortcut. After the first manual close the shortcut works (maybe a problem with Tilix, I did not investigate it further).

fixes #58