### PR TITLE
Port to GNOME 45, add gap setting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,43 +1,26 @@
-'use strict';
-
-/* eslint-env node */
 module.exports = {
-	root: true,
-	parserOptions: {
-		sourceType: 'script',
-	},
-	env: {
-		'es2017': true,
-	},
-	globals: {
-		global: "readonly",
-		imports: "readonly",
-		log: "readonly",
-	},
-	extends: 'eslint:recommended',
-	rules: {
-		'indent': [ 1, 'tab' ],
-		'quotes': [ 0, 'double', 'avoid-escape' ],
-		'linebreak-style': [ 1, 'unix' ],
-		'newline-after-var': [ 0, 'always' ],
-		'semi': [ 1, 'always' ],
-		'operator-assignment': [ 1, 'always' ],
-		'block-spacing': [ 1, 'always' ],
-		'operator-linebreak': [ 1, 'before' ],
-		'constructor-super': 1,
-		'no-console': 0,
-		'no-unused-vars': 1,
-		'no-trailing-spaces': 1,
-		'keyword-spacing': 1,
-		'camelcase': 0,
-		'no-extra-semi': 1,
-		'strict': [ 1, 'global' ],
-		'comma-dangle': [ 1, 'only-multiline' ],
-		'no-else-return': 1,
-		'yield-star-spacing': [ 1, 'after' ],
-		'no-mixed-spaces-and-tabs': [ 1, 'smart-tabs' ],
-		'array-bracket-spacing': [ 1, 'always' ],
-		'object-curly-spacing': [ 1, 'always' ],
-		'space-in-parens': 1,
-	}
+  env: {
+    es2021: true,
+  },
+  globals: {
+    global: "readonly",
+    log: "readonly",
+  },
+  extends: "eslint:recommended",
+  overrides: [
+    {
+      env: {
+        node: true,
+      },
+      files: [".eslintrc.{js,cjs}"],
+      parserOptions: {
+        sourceType: "script",
+      },
+    },
+  ],
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  rules: {},
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/
 locale/
+node_modules/
 *.po~
 *.pot~
 gschemas.compiled

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ gnome-extensions install quake-mode@repsac-by.github.com.shell-extension.zip
 ```
 
 ## Know issues
-Due to the implementation of some tricks of initial placement of the window in the desired location on the screen and suppression of the  initial animation with replacement of its own, it may not always work correctly.
+
+Due to the implementation of some tricks of initial placement of the window in the desired location on the screen and suppression of the initial animation with replacement of its own, it may not always work correctly.
 
 ## P.S.
+
 Developed for usage [tilix](https://github.com/gnunn1/tilix) on wayland but can manage almost any application.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,31 +1,62 @@
-declare interface GjsGiImports {
-	Clutter: typeof import( "@gi-types/clutter10" );
-	Gdk: typeof import( "@gi-types/gdk3" ) | typeof import( "@gi-types/gdk4" );
-	Gtk: typeof import( "@gi-types/gtk3" );
-	Meta: typeof import( "@gi-types/meta10" );
-	Shell: typeof import( "@gi-types/shell0" );
-	St: typeof import( "@gi-types/st1" );
+// TODO: contribute these types to @girs
+
+interface ImportMeta {
+  url: string;
 }
 
-declare interface GjsImports {
-	misc: {
-		extensionUtils: {
-			getCurrentExtension(): {
-				imports: {
-					quakemodeapp: import( './quake-mode@repsac-by.github.com/quakemodeapp' ).types;
-					indicator: import('./quake-mode@repsac-by.github.com/indicator').types;
-					util: import( './quake-mode@repsac-by.github.com/util' ).types;
-				};
-			};
-			getSettings(): import('@gi-types/gio2').Settings;
-			gettext: typeof imports.gettext.gettext;
-			initTranslations(): void;
-			openPrefs(): void;
-		}
-	}
-	ui: {
-		[key: string]: any;
-	};
+declare const global: any;
+
+type MethodNames<T extends object> = {
+  [K in keyof T]: T[K] extends Function ? K : never;
+}[keyof T];
+
+declare module "resource:///org/gnome/shell/extensions/extension.js" {
+  type CreateOverrideFunc<
+    O extends object,
+    F extends (...args: any[]) => any,
+  > = (originalMethod: F) => (this: O, ...args: Parameters<F>) => ReturnType<F>;
+
+  export class InjectionManager {
+    /**
+     * Modify, replace or inject a method
+     *
+     * @param prototype - the object (or prototype) that is modified
+     * @param methodName - the name of the overwritten method
+     * @param createOverrideFunc - function to call to create the override
+     */
+    overrideMethod<P extends object, MN extends MethodNames<P>>(
+      prototype: P,
+      methodName: MN,
+      // @ts-expect-error It works
+      createOverrideFunc: CreateOverrideFunc<P, P[MN]>,
+    ): void;
+
+    /**
+     * Restore the original method
+     *
+     * @param prototype - the object (or prototype) that is modified
+     * @param methodName - the name of the method to restore
+     */
+    restoreMethod(prototype: object, methodName: string): void;
+
+    /**
+     * Restore all original methods and clear overrides
+     */
+    clear(): void;
+
+    _saveMethod(prototype: object, methodName: string): void;
+
+    _installMethod(
+      prototype: object,
+      methodName: string,
+      method: Function,
+    ): void;
+  }
 }
 
-declare const global: import('@gi-types/shell0').Global;
+declare module "resource:///org/gnome/shell/ui/workspace.js" {
+  import type Meta from "gi://Meta";
+  export class Workspace {
+    _isOverviewWindow(window: Meta.Window): boolean;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1495 @@
+{
+  "name": "quake-mode",
+  "version": "0.0.8",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quake-mode",
+      "version": "0.0.8",
+      "license": "MIT",
+      "devDependencies": {
+        "@gi-types/gdk4": "^4.0.1",
+        "@gi-types/gjs-environment": "^1.1.0",
+        "@gi-types/shell0": "^0.1.1",
+        "eslint": "^8.26.0",
+        "typescript": "^4.8.4"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
+      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
+      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
+      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gi-types/atk1": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@gi-types/atk1/-/atk1-2.36.0.tgz",
+      "integrity": "sha512-lCuoaJwqFDV+V+sf4mOcciLCJitiUsGNg/W2Q5Y+21FycPZqlsjgXb0pimo7gLdq11d1lEfHffh3AkY80+7SHw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/glib2": "^2.68.0",
+        "@gi-types/gobject2": "^2.68.0"
+      }
+    },
+    "node_modules/@gi-types/cairo1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/cairo1/-/cairo1-1.0.1.tgz",
+      "integrity": "sha512-Q92XKfTWVmtF3LBX9Kx7TkdRjeaZeb8llC01p9WgbkVfFX1d2VO4LrqYgeNkThwmJpscHzDzGF0uv5njsfd4xg==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/cally10": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/cally10/-/cally10-10.0.1.tgz",
+      "integrity": "sha512-q4QOjuvXtVxHPC81eWkUl3cmnTjn5VgfhdMyphnym4vRd1JmBpYCQxvGBMpePaqwwxolgUccdVeUYv671XCenA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/atk1": "^2.36.0",
+        "@gi-types/clutter10": "^10.0.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/clutter10": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/clutter10/-/clutter10-10.0.1.tgz",
+      "integrity": "sha512-RID6cMWeIFP4ikkd3GLymEG/KbWnQYBz3DAte+HjWOxbP/yAKlfDWrz3CwVM0NO+pIbD7zeCgdFbcCaXC9u2Ww==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/atk1": "^2.36.0",
+        "@gi-types/cairo1": "^1.0.1",
+        "@gi-types/cogl10": "^10.0.1",
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/graphene1": "^1.0.1",
+        "@gi-types/json1": "^1.6.1",
+        "@gi-types/pango1": "^1.50.1"
+      }
+    },
+    "node_modules/@gi-types/cogl10": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/cogl10/-/cogl10-10.0.1.tgz",
+      "integrity": "sha512-n4Kf019kVog/X+YCjvIBXKgOv5zmJWaWHjpPViKs4ydH5X/LKqM23EpYGvyvDgFOFV4y/cv9i6/RMcb5rgCeHA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/cairo1": "^1.0.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/graphene1": "^1.0.1"
+      }
+    },
+    "node_modules/@gi-types/freetype22": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/freetype22/-/freetype22-2.0.1.tgz",
+      "integrity": "sha512-3p4XvTSn6o1UCGpla/1KhvMIwZkgIyBtGErbnXuAvGzULtlseQjX2IljY4fi2FKtFd9ngRtIIF71inRPUIj+1w==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gck1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gck1/-/gck1-1.0.1.tgz",
+      "integrity": "sha512-EkLhQvsb/qHBffTJ5j9aK/KX2nE8LTHDbPSMrXtaTWz3yQYuRDqTyXJWVVUxfcXwKliE9GYyqEOAiXlXCamFHQ==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gcr3": {
+      "version": "3.41.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gcr3/-/gcr3-3.41.1.tgz",
+      "integrity": "sha512-sZWGbOQlbtwNoggDDBqFxD1lAyGpIEg7TR5RVVrcQfaMwo7yIkRahvXCy7XCoYnWsEmAw46fEdUI5408Ykn8/g==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gck1": "^1.0.1",
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gdesktopenums3": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gdesktopenums3/-/gdesktopenums3-3.0.1.tgz",
+      "integrity": "sha512-qIzerTlLUhoMXS6TCV0vxNaYFBs1Oy4BY84srjv3NYsCG2auWGVNRVS2qn1r9ztRpWwAzEYO4KASitVi5zUoGA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.68.0"
+      }
+    },
+    "node_modules/@gi-types/gdk3": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gdk3/-/gdk3-3.24.1.tgz",
+      "integrity": "sha512-0RLHMYjpuWSgnOgC83ThEPTQREnRR3wuxuYj6zfWSwmSJarLpSM0hCo8Xszew2k7RW/tybUqEfPdH4Bw7dnbJA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/cairo1": "^1.0.0",
+        "@gi-types/gdkpixbuf2": "^2.0.0",
+        "@gi-types/gio2": "^2.68.0",
+        "@gi-types/glib2": "^2.68.0",
+        "@gi-types/gobject2": "^2.68.0",
+        "@gi-types/pango1": "^1.0.0"
+      }
+    },
+    "node_modules/@gi-types/gdk4": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gdk4/-/gdk4-4.0.1.tgz",
+      "integrity": "sha512-Msf4bWdw8A0qorTvbvWgCwMno8nUCGLiDcEhNI6iqh6o8IJKchID9a51j6KeqpHkwSPZAcaR2TKM+CVafa4pOw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/cairo1": "^1.0.0",
+        "@gi-types/gdkpixbuf2": "^2.0.0",
+        "@gi-types/gio2": "^2.68.0",
+        "@gi-types/glib2": "^2.68.0",
+        "@gi-types/gobject2": "^2.68.0",
+        "@gi-types/pango1": "^1.0.0"
+      }
+    },
+    "node_modules/@gi-types/gdkpixbuf2": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@gi-types/gdkpixbuf2/-/gdkpixbuf2-2.0.2.tgz",
+      "integrity": "sha512-vwopihyKOjJszDPvMj+T2XO6hMWYRmhW/uSrfCeCudMhzmJBrpIzmRZTYfeTgMMDU8cuWydCjacbiD7hSio0tw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gmodule2": "^2.0.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gio2": {
+      "version": "2.72.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gio2/-/gio2-2.72.1.tgz",
+      "integrity": "sha512-V3ASxEbq4xBdw/rcROEbNrTqtFtWfwFOcOsXO+48JPIEqZRTJZcf9LX/ATxi9hxaZXogpmOBMsxuyNsd5ZQXyA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gjs-environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gi-types/gjs-environment/-/gjs-environment-1.1.0.tgz",
+      "integrity": "sha512-WXQ1xwuLou5qobQ76LyYxU5bgZYNbkypm3ZLphNWZLuj8C9MbWmb9BJihdq2IAAyH6+HIrrN6ss1syu7IJZUaA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.68.0",
+        "@gi-types/glib2": "^2.68.0",
+        "@gi-types/gobject2": "^2.68.0"
+      }
+    },
+    "node_modules/@gi-types/glib2": {
+      "version": "2.72.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/glib2/-/glib2-2.72.1.tgz",
+      "integrity": "sha512-Mfhs1UGV1a0GOLolqA1xC2oVV5cILbJjGh/M9Db3irqWNIWGM0LUFkoG2nRMBpJ0enhIYbqY9CCpGlMpAnyxOw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gmodule2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gmodule2/-/gmodule2-2.0.1.tgz",
+      "integrity": "sha512-thIYqYL3ALKBLR/zpjrlXro1m9UTv6eAYyuIdpPtmQvlaggBLoUakYl6mzNmqcb22OIlq/8jJrVx+cjFxdPd/A==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/gobject2": {
+      "version": "2.72.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gobject2/-/gobject2-2.72.1.tgz",
+      "integrity": "sha512-1UUD2zzwRo7vJLu0J62L1cgB39wjYNs1+6qS0UBhdLhzkOWK+CnVII9CNh21Z4YBs0Oa2d5REeGUiZO4d7a6Zw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/glib2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/graphene1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/graphene1/-/graphene1-1.0.1.tgz",
+      "integrity": "sha512-O5cJG/eIi912eF1zcaXrSur25LgMJDU+VhFDnYuO4Latj32eypFJf5Sw3KOZvN2EoctIBxjutbXLOxYYKMBhHA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.68.0"
+      }
+    },
+    "node_modules/@gi-types/gtk3": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/gtk3/-/gtk3-3.24.1.tgz",
+      "integrity": "sha512-KW+ilICTJxl2OrtPbKRMEzA4+QTziZCD33O4ipIqWUjy7YJHaGgBUCNtzzBL9VfunGBBVfClIc4cVcLhV/pbBA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/atk1": "^2.36.0",
+        "@gi-types/cairo1": "^1.0.0",
+        "@gi-types/gdk3": "^3.24.1",
+        "@gi-types/gdkpixbuf2": "^2.0.0",
+        "@gi-types/gio2": "^2.68.0",
+        "@gi-types/glib2": "^2.68.0",
+        "@gi-types/gobject2": "^2.68.0",
+        "@gi-types/pango1": "^1.0.0",
+        "@gi-types/xlib2": "^2.0.0"
+      }
+    },
+    "node_modules/@gi-types/harfbuzz2": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@gi-types/harfbuzz2/-/harfbuzz2-4.4.2.tgz",
+      "integrity": "sha512-jsntc6SthoOdw4VSetTOKFI0BM1ccDISP1JQhnL5NETrVuYGnNAwRZ2oDIujuG0M70bHDv/MWKiZnmJxXNPrKw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/freetype22": "^2.0.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/json1": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/json1/-/json1-1.6.1.tgz",
+      "integrity": "sha512-6DpNf3PTYYKbL96U76R/mWZuAXv32cI0ZDalyKAciKeh9pczHjlnNdjq8h6lDKJc5vKxviHW9TsOdtB3NaXuqQ==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/meta10": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/meta10/-/meta10-10.0.1.tgz",
+      "integrity": "sha512-VmYij7FhqC5CtYrWcheErwiVwmiPOJ55Ct71Q7daZPAQi358hUYsya0WYBPAXGciIMdd67UjorZX6DYfAAksRw==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/atk1": "^2.36.0",
+        "@gi-types/cairo1": "^1.0.1",
+        "@gi-types/clutter10": "^10.0.1",
+        "@gi-types/cogl10": "^10.0.1",
+        "@gi-types/gdesktopenums3": "^3.0.1",
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/graphene1": "^1.0.1",
+        "@gi-types/gtk3": "^3.24.1",
+        "@gi-types/json1": "^1.6.1",
+        "@gi-types/pango1": "^1.50.1",
+        "@gi-types/xfixes4": "^4.0.1",
+        "@gi-types/xlib2": "^2.0.1"
+      }
+    },
+    "node_modules/@gi-types/nm1": {
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/nm1/-/nm1-1.38.1.tgz",
+      "integrity": "sha512-TZNDTSxPRFjv+kjI/RyqLBO9Rb1FVDuUTfUyB9znGuj4NnPvQ5lzLRlvSG5SIyRYbeu1hik7lGteK+mM/NslVQ==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/pango1": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/pango1/-/pango1-1.50.1.tgz",
+      "integrity": "sha512-SdpoZ5Fcz7Zo8Tal5Ap4Z/4SMqpo/PspORIadxmNZ3kafFOwK7TPvdWiUIBgua+i3uWiLnreKCGD/6rLJLbw3g==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/harfbuzz2": "^4.4.2"
+      }
+    },
+    "node_modules/@gi-types/polkit1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/polkit1/-/polkit1-1.0.1.tgz",
+      "integrity": "sha512-M+9OPCx0jeOGe28uN6fegTsYOMuNnjZbgw1sJp6wXRRswihaceqHvuKSePo7dhyC+rx8knS04Cde1rYFQlZiBg==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/polkitagent1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/polkitagent1/-/polkitagent1-1.0.1.tgz",
+      "integrity": "sha512-klFuDVAoFomKpQBx6JtigNhAiuMnkeKEUj8pewR+n3wraVFJ1K/pyT/O14UYR6Qgl8smOBFybyQv15tgc35HnA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/polkit1": "^1.0.1"
+      }
+    },
+    "node_modules/@gi-types/shell0": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/shell0/-/shell0-0.1.1.tgz",
+      "integrity": "sha512-uxaOslRprg4qHYqVtAW7vABpj+T/RjpQJcVINk5MKvMvRttbGX+GD6Ky1d9M7GK+7+R3MIaYoTSCpHD2GeBkTA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/atk1": "^2.36.0",
+        "@gi-types/cairo1": "^1.0.1",
+        "@gi-types/clutter10": "^10.0.1",
+        "@gi-types/cogl10": "^10.0.1",
+        "@gi-types/gcr3": "^3.41.1",
+        "@gi-types/gdkpixbuf2": "^2.0.2",
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/graphene1": "^1.0.1",
+        "@gi-types/gtk3": "^3.24.1",
+        "@gi-types/meta10": "^10.0.1",
+        "@gi-types/nm1": "^1.38.1",
+        "@gi-types/polkitagent1": "^1.0.1",
+        "@gi-types/st1": "^1.0.1"
+      }
+    },
+    "node_modules/@gi-types/st1": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/st1/-/st1-1.0.1.tgz",
+      "integrity": "sha512-vpS4n36J2rI4gL2FEYTL/+yrjEdJjEVuV+g7bSnteZQOLyuLZjaB2noXFnvsQ30Cfp1rHD+uinY86cPaJv/ARA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/atk1": "^2.36.0",
+        "@gi-types/cairo1": "^1.0.1",
+        "@gi-types/cally10": "^10.0.1",
+        "@gi-types/clutter10": "^10.0.1",
+        "@gi-types/cogl10": "^10.0.1",
+        "@gi-types/gio2": "^2.72.1",
+        "@gi-types/glib2": "^2.72.1",
+        "@gi-types/gobject2": "^2.72.1",
+        "@gi-types/json1": "^1.6.1",
+        "@gi-types/pango1": "^1.50.1"
+      }
+    },
+    "node_modules/@gi-types/xfixes4": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/xfixes4/-/xfixes4-4.0.1.tgz",
+      "integrity": "sha512-2B9XqWAE7JpdZwuUDZ+YrwTu45nuKU05RH8qXv9ld3ypmdVRVx5J8qb+VVaI3z6H6EOPfz0lYsxRmvAT8GLZsA==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@gi-types/xlib2": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gi-types/xlib2/-/xlib2-2.0.1.tgz",
+      "integrity": "sha512-AouZupNa8roCOwKbyGuVuOmt7n8YYBprH60q5Ggu9vGVY+AhpTjEbeJBiLkHW74T8587Z3AilRo7cBWnXPM56A==",
+      "dev": true,
+      "dependencies": {
+        "@gi-types/gobject2": "^2.72.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
+      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
+      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.1.0",
+        "@eslint/js": "8.44.0",
+        "@humanwhocodes/config-array": "^0.11.10",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.1",
+        "espree": "^9.6.0",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
+      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "dev": true
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "quake-mode",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quake-mode",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "devDependencies": {
-        "@gi-types/gdk4": "^4.0.1",
-        "@gi-types/gjs-environment": "^1.1.0",
-        "@gi-types/shell0": "^0.1.1",
-        "eslint": "^8.26.0",
-        "typescript": "^4.8.4"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gnome-shell": "^45.0.0-beta5",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/gtk-4.0": "^4.12.3-3.2.6",
+        "eslint": "^8.55.0",
+        "prettier": "^3.1.0",
+        "typescript": "^5.3.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -41,18 +43,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -73,385 +75,729 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+      "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@gi-types/atk1": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@gi-types/atk1/-/atk1-2.36.0.tgz",
-      "integrity": "sha512-lCuoaJwqFDV+V+sf4mOcciLCJitiUsGNg/W2Q5Y+21FycPZqlsjgXb0pimo7gLdq11d1lEfHffh3AkY80+7SHw==",
+    "node_modules/@girs/accountsservice-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/accountsservice-1.0/-/accountsservice-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-2IqT7F94sboFobVAwEFkut1kzXn1ISh2mc4YeuF2qbvfT1HokwbPqIc13ae9KDFw6H0umvaDdXbcSfm+8QDHRQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/glib2": "^2.68.0",
-        "@gi-types/gobject2": "^2.68.0"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/cairo1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/cairo1/-/cairo1-1.0.1.tgz",
-      "integrity": "sha512-Q92XKfTWVmtF3LBX9Kx7TkdRjeaZeb8llC01p9WgbkVfFX1d2VO4LrqYgeNkThwmJpscHzDzGF0uv5njsfd4xg==",
+    "node_modules/@girs/adw-1": {
+      "version": "1.4.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/adw-1/-/adw-1-1.4.0-3.2.6.tgz",
+      "integrity": "sha512-bnim64bRBv+WB3Sfsmcq9nh2Iq8PG0axJLqVBG9lgT8KsZZvVHWLv3rR6Hye9MXaySz7vQ1Ne0beXkl17Iseaw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdk-4.0": "^4.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/gsk-4.0": "^4.0.0-3.2.6",
+        "@girs/gtk-4.0": "^4.12.3-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/cally10": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/cally10/-/cally10-10.0.1.tgz",
-      "integrity": "sha512-q4QOjuvXtVxHPC81eWkUl3cmnTjn5VgfhdMyphnym4vRd1JmBpYCQxvGBMpePaqwwxolgUccdVeUYv671XCenA==",
+    "node_modules/@girs/atk-1.0": {
+      "version": "2.50.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/atk-1.0/-/atk-1.0-2.50.0-3.2.6.tgz",
+      "integrity": "sha512-u6aXdrD4za3F8w3lSsXOGnmaOsonr5WzbMVawIaYdzyni+0GTZWUoAsmPeELFSXybRJY7zAJuIho1F0nO030KQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/atk1": "^2.36.0",
-        "@gi-types/clutter10": "^10.0.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/clutter10": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/clutter10/-/clutter10-10.0.1.tgz",
-      "integrity": "sha512-RID6cMWeIFP4ikkd3GLymEG/KbWnQYBz3DAte+HjWOxbP/yAKlfDWrz3CwVM0NO+pIbD7zeCgdFbcCaXC9u2Ww==",
+    "node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-cQa1/DpWc3bysBVZlvQCPQXRTFGQQk89iVQe3aU3hLK4NpTSIZrgx0DpIfgR0/mgwGZOFpJyN4eZC63JXZlZnw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/atk1": "^2.36.0",
-        "@gi-types/cairo1": "^1.0.1",
-        "@gi-types/cogl10": "^10.0.1",
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/graphene1": "^1.0.1",
-        "@gi-types/json1": "^1.6.1",
-        "@gi-types/pango1": "^1.50.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/cogl10": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/cogl10/-/cogl10-10.0.1.tgz",
-      "integrity": "sha512-n4Kf019kVog/X+YCjvIBXKgOv5zmJWaWHjpPViKs4ydH5X/LKqM23EpYGvyvDgFOFV4y/cv9i6/RMcb5rgCeHA==",
+    "node_modules/@girs/cally-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/cally-13/-/cally-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-09x4H1uBEgVa3Dn1MNVV7TxPQkN7O2VlW27Qei/fckrPwnoUlT0UtG+b24YLFNrA5u0AMDWvJMXU1jksjWPBPw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/cairo1": "^1.0.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/graphene1": "^1.0.1"
+        "@girs/atk-1.0": "^2.50.0-3.2.6",
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/clutter-13": "^13.0.0-3.2.6",
+        "@girs/cogl-13": "^13.0.0-3.2.6",
+        "@girs/coglpango-13": "^13.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/json-1.0": "^1.7.1-3.2.6",
+        "@girs/mtk-13": "^13.0.0-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/freetype22": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/freetype22/-/freetype22-2.0.1.tgz",
-      "integrity": "sha512-3p4XvTSn6o1UCGpla/1KhvMIwZkgIyBtGErbnXuAvGzULtlseQjX2IljY4fi2FKtFd9ngRtIIF71inRPUIj+1w==",
+    "node_modules/@girs/clutter-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/clutter-13/-/clutter-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-fltUmKy8Gv8EZuX1OVFf+S98ZTR2S/Zqm6ToapACRuas9IAj+9sribKLOWwYuqy+JKqVTJQOX+3GnypNPHG54w==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/atk-1.0": "^2.50.0-3.2.6",
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/cogl-13": "^13.0.0-3.2.6",
+        "@girs/coglpango-13": "^13.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/json-1.0": "^1.7.1-3.2.6",
+        "@girs/mtk-13": "^13.0.0-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gck1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gck1/-/gck1-1.0.1.tgz",
-      "integrity": "sha512-EkLhQvsb/qHBffTJ5j9aK/KX2nE8LTHDbPSMrXtaTWz3yQYuRDqTyXJWVVUxfcXwKliE9GYyqEOAiXlXCamFHQ==",
+    "node_modules/@girs/cogl-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/cogl-13/-/cogl-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-zfOlLf/5oDwWtiB/OO/kMERNTbTH9yXF0xg2stpQyrhvNxpUHs3OE7VS5Ad2+Guu5k8oUrwPHzzu6E8bk77p8A==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gcr3": {
-      "version": "3.41.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gcr3/-/gcr3-3.41.1.tgz",
-      "integrity": "sha512-sZWGbOQlbtwNoggDDBqFxD1lAyGpIEg7TR5RVVrcQfaMwo7yIkRahvXCy7XCoYnWsEmAw46fEdUI5408Ykn8/g==",
+    "node_modules/@girs/cogl-2.0": {
+      "version": "2.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/cogl-2.0/-/cogl-2.0-2.0.0-3.2.6.tgz",
+      "integrity": "sha512-Lu58bK4sT7xpfqE+yxJ+LZLE++Z15r9bOGWNQqkb5ffn776FeU8pcGW1sZK/Qpp6YuO2jPU50V0vOoEi+f4NvQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gck1": "^1.0.1",
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gdesktopenums3": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gdesktopenums3/-/gdesktopenums3-3.0.1.tgz",
-      "integrity": "sha512-qIzerTlLUhoMXS6TCV0vxNaYFBs1Oy4BY84srjv3NYsCG2auWGVNRVS2qn1r9ztRpWwAzEYO4KASitVi5zUoGA==",
+    "node_modules/@girs/coglpango-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/coglpango-13/-/coglpango-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-Vo7EoL2mjnv0mAyaOZj+vJbEkciz28R/Q4nMhIkf1ulhBYAdpCfhJDrhn9514Zeyd9MlDD2Ss/t6RzbgGWXOJw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.68.0"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/cogl-13": "^13.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gdk3": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gdk3/-/gdk3-3.24.1.tgz",
-      "integrity": "sha512-0RLHMYjpuWSgnOgC83ThEPTQREnRR3wuxuYj6zfWSwmSJarLpSM0hCo8Xszew2k7RW/tybUqEfPdH4Bw7dnbJA==",
+    "node_modules/@girs/freetype2-2.0": {
+      "version": "2.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-3.2.6.tgz",
+      "integrity": "sha512-E8utYdnopbL0DxArc6KE95824xuWomzkEydVxNsaJqksusvItJR9T85JhQeHwtcKZbfxuFvrglO8cCCL7LrCLA==",
       "dev": true,
       "dependencies": {
-        "@gi-types/cairo1": "^1.0.0",
-        "@gi-types/gdkpixbuf2": "^2.0.0",
-        "@gi-types/gio2": "^2.68.0",
-        "@gi-types/glib2": "^2.68.0",
-        "@gi-types/gobject2": "^2.68.0",
-        "@gi-types/pango1": "^1.0.0"
+        "@girs/gjs": "^3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gdk4": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gdk4/-/gdk4-4.0.1.tgz",
-      "integrity": "sha512-Msf4bWdw8A0qorTvbvWgCwMno8nUCGLiDcEhNI6iqh6o8IJKchID9a51j6KeqpHkwSPZAcaR2TKM+CVafa4pOw==",
+    "node_modules/@girs/gck-2": {
+      "version": "4.1.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gck-2/-/gck-2-4.1.0-3.2.6.tgz",
+      "integrity": "sha512-X8YaXQ+1lYs4Pd6oH1X2plCQig43doVoikaGFyuEe2How2AY5nvU41VX8KdaJhPam71fpwVczn32Qk9DE9julA==",
       "dev": true,
       "dependencies": {
-        "@gi-types/cairo1": "^1.0.0",
-        "@gi-types/gdkpixbuf2": "^2.0.0",
-        "@gi-types/gio2": "^2.68.0",
-        "@gi-types/glib2": "^2.68.0",
-        "@gi-types/gobject2": "^2.68.0",
-        "@gi-types/pango1": "^1.0.0"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gdkpixbuf2": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@gi-types/gdkpixbuf2/-/gdkpixbuf2-2.0.2.tgz",
-      "integrity": "sha512-vwopihyKOjJszDPvMj+T2XO6hMWYRmhW/uSrfCeCudMhzmJBrpIzmRZTYfeTgMMDU8cuWydCjacbiD7hSio0tw==",
+    "node_modules/@girs/gcr-4": {
+      "version": "4.1.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gcr-4/-/gcr-4-4.1.0-3.2.6.tgz",
+      "integrity": "sha512-ZfDt+97S10UJsX+IBeJ4UUyfMBlJtZACf4tqaFKklMBYcPGmHL4MvMuRcetsq+S2njqG+Bdim8vmnOSTAEJn2A==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gmodule2": "^2.0.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gck-2": "^4.1.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gio2": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gio2/-/gio2-2.72.1.tgz",
-      "integrity": "sha512-V3ASxEbq4xBdw/rcROEbNrTqtFtWfwFOcOsXO+48JPIEqZRTJZcf9LX/ATxi9hxaZXogpmOBMsxuyNsd5ZQXyA==",
+    "node_modules/@girs/gdesktopenums-3.0": {
+      "version": "3.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gdesktopenums-3.0/-/gdesktopenums-3.0-3.0.0-3.2.6.tgz",
+      "integrity": "sha512-Tat1g8moEMtvNnhZH56d35u6alAblA3Usxw4ugE76aXG7lhIdn1JkImzEDBeQtr0mM7SE+U8DkjBux6iQWUfVw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gjs-environment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@gi-types/gjs-environment/-/gjs-environment-1.1.0.tgz",
-      "integrity": "sha512-WXQ1xwuLou5qobQ76LyYxU5bgZYNbkypm3ZLphNWZLuj8C9MbWmb9BJihdq2IAAyH6+HIrrN6ss1syu7IJZUaA==",
+    "node_modules/@girs/gdk-4.0": {
+      "version": "4.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-3.2.6.tgz",
+      "integrity": "sha512-HKdl6+WPjn0lXmlH9tf1mKBnOUbzlQ2blLQ+MTxoXK+202POCZYz1gHBuvy+GH48pGKpOwTo1oP3NOcoRVMCfA==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.68.0",
-        "@gi-types/glib2": "^2.68.0",
-        "@gi-types/gobject2": "^2.68.0"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/glib2": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/glib2/-/glib2-2.72.1.tgz",
-      "integrity": "sha512-Mfhs1UGV1a0GOLolqA1xC2oVV5cILbJjGh/M9Db3irqWNIWGM0LUFkoG2nRMBpJ0enhIYbqY9CCpGlMpAnyxOw==",
+    "node_modules/@girs/gdkpixbuf-2.0": {
+      "version": "2.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-3.2.6.tgz",
+      "integrity": "sha512-iJyUeBzd09Qz6XgfCU0j22cG9xUmRW7V2Y8Uak04NEDt0JmbjIsTnsLUS1dtJ+pJH7+qccijJHVzTbQPnNVUsQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gmodule2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gmodule2/-/gmodule2-2.0.1.tgz",
-      "integrity": "sha512-thIYqYL3ALKBLR/zpjrlXro1m9UTv6eAYyuIdpPtmQvlaggBLoUakYl6mzNmqcb22OIlq/8jJrVx+cjFxdPd/A==",
+    "node_modules/@girs/gdm-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gdm-1.0/-/gdm-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-fEuRcaf71xLYtiFddZtdiyoO3HSyeTqAkTAQ2Tn/tC4d1NEEIcuiR1tljdV6URf0B5ajSXGWuUsxldxDqosPaQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gobject2": {
-      "version": "2.72.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gobject2/-/gobject2-2.72.1.tgz",
-      "integrity": "sha512-1UUD2zzwRo7vJLu0J62L1cgB39wjYNs1+6qS0UBhdLhzkOWK+CnVII9CNh21Z4YBs0Oa2d5REeGUiZO4d7a6Zw==",
+    "node_modules/@girs/gio-2.0": {
+      "version": "2.78.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.78.0-3.2.6.tgz",
+      "integrity": "sha512-MmPAB3gB5V2I5sfrbsj9D5/+iIcbkfqDYq8fAgLXav558xSDNjux+lNykxawL1oCNcxr+kC2PguYhnLEFCgxmA==",
       "dev": true,
       "dependencies": {
-        "@gi-types/glib2": "^2.72.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/graphene1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/graphene1/-/graphene1-1.0.1.tgz",
-      "integrity": "sha512-O5cJG/eIi912eF1zcaXrSur25LgMJDU+VhFDnYuO4Latj32eypFJf5Sw3KOZvN2EoctIBxjutbXLOxYYKMBhHA==",
+    "node_modules/@girs/gjs": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-3.2.6.tgz",
+      "integrity": "sha512-PY1i3RzkTw+kp/OKalPg5O6BHEiBq82PPq41GDivlkbrWcY1fX4UqcdjXBU7L0mRFd2po8ciVW9J0/yheyXXIg==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.68.0"
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/gtk3": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/gtk3/-/gtk3-3.24.1.tgz",
-      "integrity": "sha512-KW+ilICTJxl2OrtPbKRMEzA4+QTziZCD33O4ipIqWUjy7YJHaGgBUCNtzzBL9VfunGBBVfClIc4cVcLhV/pbBA==",
+    "node_modules/@girs/gl-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gl-1.0/-/gl-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-19LNgOqmeLVsw98EtU3GJNCe8/sOYuU9BbxOoLr7g8bi/7A0d3fLMhLfp60rYs0zl7GxPmgbh6p3DyD4cKrMwQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/atk1": "^2.36.0",
-        "@gi-types/cairo1": "^1.0.0",
-        "@gi-types/gdk3": "^3.24.1",
-        "@gi-types/gdkpixbuf2": "^2.0.0",
-        "@gi-types/gio2": "^2.68.0",
-        "@gi-types/glib2": "^2.68.0",
-        "@gi-types/gobject2": "^2.68.0",
-        "@gi-types/pango1": "^1.0.0",
-        "@gi-types/xlib2": "^2.0.0"
+        "@girs/gjs": "^3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/harfbuzz2": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@gi-types/harfbuzz2/-/harfbuzz2-4.4.2.tgz",
-      "integrity": "sha512-jsntc6SthoOdw4VSetTOKFI0BM1ccDISP1JQhnL5NETrVuYGnNAwRZ2oDIujuG0M70bHDv/MWKiZnmJxXNPrKw==",
+    "node_modules/@girs/glib-2.0": {
+      "version": "2.78.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.78.0-3.2.6.tgz",
+      "integrity": "sha512-grdCdAH+mfdzoz5iMNKsvu+BSaJWaCdLcMyoa0tq/+Rz84D/2GmLslyomjFXzA7Xr6BrIXOzgHaTuRrCZNtnmw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/freetype22": "^2.0.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/json1": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/json1/-/json1-1.6.1.tgz",
-      "integrity": "sha512-6DpNf3PTYYKbL96U76R/mWZuAXv32cI0ZDalyKAciKeh9pczHjlnNdjq8h6lDKJc5vKxviHW9TsOdtB3NaXuqQ==",
+    "node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-3.2.6.tgz",
+      "integrity": "sha512-KNkdMFTH0vzJMO/aIkLzue8xO0Oz+BlX8SbP+yVzEMtb+jlFzLd3VxA1W+60V3xpxkzSZbXbdCuSjBOx9hSaSA==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/meta10": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/meta10/-/meta10-10.0.1.tgz",
-      "integrity": "sha512-VmYij7FhqC5CtYrWcheErwiVwmiPOJ55Ct71Q7daZPAQi358hUYsya0WYBPAXGciIMdd67UjorZX6DYfAAksRw==",
+    "node_modules/@girs/gnome-shell": {
+      "version": "45.0.0-beta5",
+      "resolved": "https://registry.npmjs.org/@girs/gnome-shell/-/gnome-shell-45.0.0-beta5.tgz",
+      "integrity": "sha512-6QfLSkZIRvjPNtKm2cEWs7EOO4lAgOq9/sSxtWcCZ39j8soid3QWlTuOA0tY6modb/0IGOthBDJHgwKIx1X4zA==",
       "dev": true,
       "dependencies": {
-        "@gi-types/atk1": "^2.36.0",
-        "@gi-types/cairo1": "^1.0.1",
-        "@gi-types/clutter10": "^10.0.1",
-        "@gi-types/cogl10": "^10.0.1",
-        "@gi-types/gdesktopenums3": "^3.0.1",
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/graphene1": "^1.0.1",
-        "@gi-types/gtk3": "^3.24.1",
-        "@gi-types/json1": "^1.6.1",
-        "@gi-types/pango1": "^1.50.1",
-        "@gi-types/xfixes4": "^4.0.1",
-        "@gi-types/xlib2": "^2.0.1"
+        "@girs/accountsservice-1.0": "^1.0.0-3.2.6",
+        "@girs/adw-1": "^1.4.0-3.2.6",
+        "@girs/atk-1.0": "^2.50.0-3.2.6",
+        "@girs/cally-13": "^13.0.0-3.2.6",
+        "@girs/clutter-13": "^13.0.0-3.2.6",
+        "@girs/cogl-2.0": "^2.0.0-3.2.6",
+        "@girs/gcr-4": "^4.1.0-3.2.6",
+        "@girs/gdm-1.0": "^1.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gnomebg-4.0": "^4.0.0-3.2.6",
+        "@girs/gnomebluetooth-3.0": "^3.0.0-3.2.6",
+        "@girs/gnomedesktop-4.0": "^4.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/gtk-4.0": "^4.12.3-3.2.6",
+        "@girs/gvc-1.0": "^1.0.0-3.2.6",
+        "@girs/meta-13": "^13.0.0-3.2.6",
+        "@girs/polkit-1.0": "^1.0.0-3.2.6",
+        "@girs/shell-13": "^13.0.0-3.2.6",
+        "@girs/shew-0": "^0.0.0-3.2.6",
+        "@girs/st-13": "^13.0.0-3.2.6",
+        "@girs/upowerglib-1.0": "^0.99.1-3.2.6"
       }
     },
-    "node_modules/@gi-types/nm1": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/nm1/-/nm1-1.38.1.tgz",
-      "integrity": "sha512-TZNDTSxPRFjv+kjI/RyqLBO9Rb1FVDuUTfUyB9znGuj4NnPvQ5lzLRlvSG5SIyRYbeu1hik7lGteK+mM/NslVQ==",
+    "node_modules/@girs/gnomebg-4.0": {
+      "version": "4.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gnomebg-4.0/-/gnomebg-4.0-4.0.0-3.2.6.tgz",
+      "integrity": "sha512-COeXYBOsDov6p9cNUP2bMxmWFPtI5w9SnKGyGmCq+4ZktSSjSTUCg+ZXUHu8emYZBSbBRlLyiMrK9ZZBFIV+sg==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdesktopenums-3.0": "^3.0.0-3.2.6",
+        "@girs/gdk-4.0": "^4.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gnomedesktop-4.0": "^4.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/pango1": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/pango1/-/pango1-1.50.1.tgz",
-      "integrity": "sha512-SdpoZ5Fcz7Zo8Tal5Ap4Z/4SMqpo/PspORIadxmNZ3kafFOwK7TPvdWiUIBgua+i3uWiLnreKCGD/6rLJLbw3g==",
+    "node_modules/@girs/gnomebluetooth-3.0": {
+      "version": "3.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gnomebluetooth-3.0/-/gnomebluetooth-3.0-3.0.0-3.2.6.tgz",
+      "integrity": "sha512-eAq+wtXzsKrCjjug07ZE5oVwse30KtNb65ZobOzlXR6Cref6uzmnb9ZjjNC7eLkSGHLi1cKPpi3WxfpLLXzEkw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/harfbuzz2": "^4.4.2"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/polkit1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/polkit1/-/polkit1-1.0.1.tgz",
-      "integrity": "sha512-M+9OPCx0jeOGe28uN6fegTsYOMuNnjZbgw1sJp6wXRRswihaceqHvuKSePo7dhyC+rx8knS04Cde1rYFQlZiBg==",
+    "node_modules/@girs/gnomedesktop-4.0": {
+      "version": "4.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gnomedesktop-4.0/-/gnomedesktop-4.0-4.0.0-3.2.6.tgz",
+      "integrity": "sha512-Ow3+VYUrmFKU9Y7nypC/fF/yOnkSNfQIvlHqevkk+hvys7VPR/52IfVHVUYmQrp1H6gJUPJLk5fjMrZw75zRQw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gdesktopenums-3.0": "^3.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/polkitagent1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/polkitagent1/-/polkitagent1-1.0.1.tgz",
-      "integrity": "sha512-klFuDVAoFomKpQBx6JtigNhAiuMnkeKEUj8pewR+n3wraVFJ1K/pyT/O14UYR6Qgl8smOBFybyQv15tgc35HnA==",
+    "node_modules/@girs/gobject-2.0": {
+      "version": "2.78.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.78.0-3.2.6.tgz",
+      "integrity": "sha512-Yyy+hTpczMgkdgVADnSt4idEa29ZKFIbQTHjZutsUkn2kF3fxQMD7fQUpr03d0DSXY7gLKMwDtXq4XkH4cy0lg==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/polkit1": "^1.0.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/shell0": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/shell0/-/shell0-0.1.1.tgz",
-      "integrity": "sha512-uxaOslRprg4qHYqVtAW7vABpj+T/RjpQJcVINk5MKvMvRttbGX+GD6Ky1d9M7GK+7+R3MIaYoTSCpHD2GeBkTA==",
+    "node_modules/@girs/graphene-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-ypxK6ZEdoVP/UaBX+SoKqFMA4mldCGNl3n+20EbaCCbMZ1thXjn6xTvuisPJS24aaCIG7peSM0WR55d8IrY1+Q==",
       "dev": true,
       "dependencies": {
-        "@gi-types/atk1": "^2.36.0",
-        "@gi-types/cairo1": "^1.0.1",
-        "@gi-types/clutter10": "^10.0.1",
-        "@gi-types/cogl10": "^10.0.1",
-        "@gi-types/gcr3": "^3.41.1",
-        "@gi-types/gdkpixbuf2": "^2.0.2",
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/graphene1": "^1.0.1",
-        "@gi-types/gtk3": "^3.24.1",
-        "@gi-types/meta10": "^10.0.1",
-        "@gi-types/nm1": "^1.38.1",
-        "@gi-types/polkitagent1": "^1.0.1",
-        "@gi-types/st1": "^1.0.1"
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/st1": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/st1/-/st1-1.0.1.tgz",
-      "integrity": "sha512-vpS4n36J2rI4gL2FEYTL/+yrjEdJjEVuV+g7bSnteZQOLyuLZjaB2noXFnvsQ30Cfp1rHD+uinY86cPaJv/ARA==",
+    "node_modules/@girs/gsk-4.0": {
+      "version": "4.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-3.2.6.tgz",
+      "integrity": "sha512-R7ZulhSmrCiOqcqBs1eE44KjdYlQ9FuO7gaanvicTaQ+Nqts8NgGF+NU+46XHD4ckshP0/rM6UmP1weVH4Sr+A==",
       "dev": true,
       "dependencies": {
-        "@gi-types/atk1": "^2.36.0",
-        "@gi-types/cairo1": "^1.0.1",
-        "@gi-types/cally10": "^10.0.1",
-        "@gi-types/clutter10": "^10.0.1",
-        "@gi-types/cogl10": "^10.0.1",
-        "@gi-types/gio2": "^2.72.1",
-        "@gi-types/glib2": "^2.72.1",
-        "@gi-types/gobject2": "^2.72.1",
-        "@gi-types/json1": "^1.6.1",
-        "@gi-types/pango1": "^1.50.1"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdk-4.0": "^4.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/xfixes4": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/xfixes4/-/xfixes4-4.0.1.tgz",
-      "integrity": "sha512-2B9XqWAE7JpdZwuUDZ+YrwTu45nuKU05RH8qXv9ld3ypmdVRVx5J8qb+VVaI3z6H6EOPfz0lYsxRmvAT8GLZsA==",
+    "node_modules/@girs/gtk-4.0": {
+      "version": "4.12.3-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.12.3-3.2.6.tgz",
+      "integrity": "sha512-Weg68QZzVe7X1YEDL/8GMWd1CqoeQbmjA3HcW23M4CeiCdEBwLUk7d/oZLcn35vDyMRmiT/83wb5F0ktXKqvKw==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdk-4.0": "^4.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/gsk-4.0": "^4.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
       }
     },
-    "node_modules/@gi-types/xlib2": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gi-types/xlib2/-/xlib2-2.0.1.tgz",
-      "integrity": "sha512-AouZupNa8roCOwKbyGuVuOmt7n8YYBprH60q5Ggu9vGVY+AhpTjEbeJBiLkHW74T8587Z3AilRo7cBWnXPM56A==",
+    "node_modules/@girs/gvc-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/gvc-1.0/-/gvc-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-jScCsKYdtxt3b7qHfsinAZ8T93NWPKakw1PVX1tor9UFCJTCUqDaISzeo8Z7mfQU2pSiLNyNfkg1rTEUw2ciAQ==",
       "dev": true,
       "dependencies": {
-        "@gi-types/gobject2": "^2.72.1"
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/harfbuzz-0.0": {
+      "version": "8.2.1-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-8.2.1-3.2.6.tgz",
+      "integrity": "sha512-SHaXwp01mfWxwAJAtagZ/b+dnqGnjzr/9qLv3KUEfBx1P3eI6oSB0xbpi+c/yXrrbIjZd1vuVkCsdchy+Spj8w==",
+      "dev": true,
+      "dependencies": {
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/json-1.0": {
+      "version": "1.7.1-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/json-1.0/-/json-1.0-1.7.1-3.2.6.tgz",
+      "integrity": "sha512-I+3NBAUx7FuQFJ4Xw5rNTy67eJYc4I4UV5lyefjtdLPJ4sm7Dq46NL999UhaHFBXkKggJpyqx6W6vHNrYouh0w==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/meta-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/meta-13/-/meta-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-Pi9+9XyfjfhMneYqKkz2LgyL6E2ZvCYmbHlYiGzC+xKH2rffIAt0jqWeI4Lo9jYIfWGrvIM2fbC0iMIpjWyG4g==",
+      "dev": true,
+      "dependencies": {
+        "@girs/atk-1.0": "^2.50.0-3.2.6",
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/clutter-13": "^13.0.0-3.2.6",
+        "@girs/cogl-13": "^13.0.0-3.2.6",
+        "@girs/coglpango-13": "^13.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdesktopenums-3.0": "^3.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/json-1.0": "^1.7.1-3.2.6",
+        "@girs/mtk-13": "^13.0.0-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6",
+        "@girs/xfixes-4.0": "^4.0.0-3.2.6",
+        "@girs/xlib-2.0": "^2.0.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/mtk-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/mtk-13/-/mtk-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-KkDE/mIQ3P8eSn9QcGbehuZHS9pYz+DORUDsIX8XU/fC9qoEUuGbHyAHn82LsphigfsMmOctsEhN6/bDyCLCmw==",
+      "dev": true,
+      "dependencies": {
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/nm-1.0": {
+      "version": "1.45.1-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/nm-1.0/-/nm-1.0-1.45.1-3.2.6.tgz",
+      "integrity": "sha512-hTi8pYm/JfaOazT6cqEWdlzwwQBs/MjzKExlP/wA0J7yQ7jDISnHFvg/pGZWQL/fp+gW/ZisejxO1/NpO2fGXA==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/pango-1.0": {
+      "version": "1.51.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.51.0-3.2.6.tgz",
+      "integrity": "sha512-8c+YXB/+OkEM0EZ3t2czVLPutklUF3AQFb6lYHrdzIYSmdMDUNCHT2dJ85ug1SKHZ/HfKl/bsMz9PTqXGYIT8Q==",
+      "dev": true,
+      "dependencies": {
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6"
+      }
+    },
+    "node_modules/@girs/pangocairo-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-5Gv7B7hdSuDu779CF45hWnirb35F9N+lgLhZ2JUGut8ljoCJ42sWnSK9wbRp4xZnLSClaBUQ8JYXVD9/0s79Tg==",
+      "dev": true,
+      "dependencies": {
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/polkit-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/polkit-1.0/-/polkit-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-E6efqfcFtwChk7VdgOS0KnD+TRQcgNqfkEgBUueAHwoZrBQrFOyOTDPdseeRVW7uEU+ARzOG/uR0/INSP0/ZXA==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/polkitagent-1.0": {
+      "version": "1.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/polkitagent-1.0/-/polkitagent-1.0-1.0.0-3.2.6.tgz",
+      "integrity": "sha512-fPdCJeAnG4wHMhJuCqXwoqNMAimDrlS+UxB1p1lT7Hu2n60tJLdv35Yrv9bF4AzwpB1lMGyW+CFd8lv03yr5Ww==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/polkit-1.0": "^1.0.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/shell-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/shell-13/-/shell-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-O3OkmNgsBcHYE4S2qh8TGvPtAMv/z+wUfjHU4bdwXZOrPVCURljkgR3D8OF1RLNkfQX0XHGAIsyl1cpzkthIwg==",
+      "dev": true,
+      "dependencies": {
+        "@girs/atk-1.0": "^2.50.0-3.2.6",
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/cally-13": "^13.0.0-3.2.6",
+        "@girs/clutter-13": "^13.0.0-3.2.6",
+        "@girs/cogl-13": "^13.0.0-3.2.6",
+        "@girs/coglpango-13": "^13.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gck-2": "^4.1.0-3.2.6",
+        "@girs/gcr-4": "^4.1.0-3.2.6",
+        "@girs/gdesktopenums-3.0": "^3.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/gvc-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/json-1.0": "^1.7.1-3.2.6",
+        "@girs/meta-13": "^13.0.0-3.2.6",
+        "@girs/mtk-13": "^13.0.0-3.2.6",
+        "@girs/nm-1.0": "^1.45.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6",
+        "@girs/polkit-1.0": "^1.0.0-3.2.6",
+        "@girs/polkitagent-1.0": "^1.0.0-3.2.6",
+        "@girs/st-13": "^13.0.0-3.2.6",
+        "@girs/xfixes-4.0": "^4.0.0-3.2.6",
+        "@girs/xlib-2.0": "^2.0.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/shew-0": {
+      "version": "0.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/shew-0/-/shew-0-0.0.0-3.2.6.tgz",
+      "integrity": "sha512-cFwnmUz4NKEdN4puRBPO39YHN+2WJk3Mq68kNvl/Sm0DvwXGxt4AWBhCCySMr6kpD0+ZW38MWCp1ZQkxfhQHkw==",
+      "dev": true,
+      "dependencies": {
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdk-4.0": "^4.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/gsk-4.0": "^4.0.0-3.2.6",
+        "@girs/gtk-4.0": "^4.12.3-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/st-13": {
+      "version": "13.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/st-13/-/st-13-13.0.0-3.2.6.tgz",
+      "integrity": "sha512-Pgeeqz9aH62S4ckQ4Ohfhh+yyNwEaxnGT0xF29VefNLMFv/5d0+meQwwGjnfjiFNApzSskGl8Qz9VBZ1REgN9w==",
+      "dev": true,
+      "dependencies": {
+        "@girs/atk-1.0": "^2.50.0-3.2.6",
+        "@girs/cairo-1.0": "^1.0.0-3.2.6",
+        "@girs/cally-13": "^13.0.0-3.2.6",
+        "@girs/clutter-13": "^13.0.0-3.2.6",
+        "@girs/cogl-13": "^13.0.0-3.2.6",
+        "@girs/coglpango-13": "^13.0.0-3.2.6",
+        "@girs/freetype2-2.0": "^2.0.0-3.2.6",
+        "@girs/gdesktopenums-3.0": "^3.0.0-3.2.6",
+        "@girs/gdkpixbuf-2.0": "^2.0.0-3.2.6",
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/gl-1.0": "^1.0.0-3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gmodule-2.0": "^2.0.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6",
+        "@girs/graphene-1.0": "^1.0.0-3.2.6",
+        "@girs/harfbuzz-0.0": "^8.2.1-3.2.6",
+        "@girs/json-1.0": "^1.7.1-3.2.6",
+        "@girs/meta-13": "^13.0.0-3.2.6",
+        "@girs/mtk-13": "^13.0.0-3.2.6",
+        "@girs/pango-1.0": "^1.51.0-3.2.6",
+        "@girs/pangocairo-1.0": "^1.0.0-3.2.6",
+        "@girs/xfixes-4.0": "^4.0.0-3.2.6",
+        "@girs/xlib-2.0": "^2.0.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/upowerglib-1.0": {
+      "version": "0.99.1-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/upowerglib-1.0/-/upowerglib-1.0-0.99.1-3.2.6.tgz",
+      "integrity": "sha512-xSfen2jNxcYm+x4E1r1CABDKBS485FoOH4RmGR6FrK0XHzKbZAQC4+uQAnmsQcKpjvectJ/Gz07ZC6/DMVNhEA==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gio-2.0": "^2.78.0-3.2.6",
+        "@girs/gjs": "^3.2.6",
+        "@girs/glib-2.0": "^2.78.0-3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/xfixes-4.0": {
+      "version": "4.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/xfixes-4.0/-/xfixes-4.0-4.0.0-3.2.6.tgz",
+      "integrity": "sha512-zlDUg9xYRpGmPg5wc2GlRUfdlNzN4AlkBg70kIcvnSLqxJcZOQPFwTwSz7GtQX6+P3bG+CfjeEB5EwU/RO7b8g==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gjs": "^3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
+      }
+    },
+    "node_modules/@girs/xlib-2.0": {
+      "version": "2.0.0-3.2.6",
+      "resolved": "https://registry.npmjs.org/@girs/xlib-2.0/-/xlib-2.0-2.0.0-3.2.6.tgz",
+      "integrity": "sha512-mXo+BEYQNEZp3pOahxt4Bl42YZTciWO2C0705o/ZKW6dQE5ky08wiG2t6Y8x0w6vYVeg9xWP9oz2jUOAdfTsdA==",
+      "dev": true,
+      "dependencies": {
+        "@girs/gjs": "^3.2.6",
+        "@girs/gobject-2.0": "^2.78.0-3.2.6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
+        "@humanwhocodes/object-schema": "^2.0.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.5"
       },
@@ -473,9 +819,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -513,10 +859,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -707,27 +1059,28 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+      "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.55.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -737,7 +1090,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -749,7 +1101,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -763,9 +1114,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -779,9 +1130,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -791,9 +1142,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -962,9 +1313,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.23.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
+      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -992,9 +1343,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1263,10 +1614,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
+      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1437,16 +1803,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
   "private": true,
   "name": "quake-mode",
-  "version": "0.0.8",
+  "version": "0.0.10",
   "description": "It's a GNOME Shell extension adds support quake-mode for any application",
   "main": "extension.js",
   "scripts": {
-    "check": "eslint quake-mode@repsac-by.github.com && tsc",
+    "check": "eslint quake-mode@repsac-by.github.com && tsc && prettier -c .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "repsac-by",
   "license": "MIT",
   "devDependencies": {
-    "@gi-types/gdk4": "^4.0.1",
-    "@gi-types/gjs-environment": "^1.1.0",
-    "@gi-types/shell0": "^0.1.1",
-    "eslint": "^8.26.0",
-    "typescript": "^4.8.4"
+    "@girs/gio-2.0": "^2.78.0-3.2.6",
+    "@girs/gnome-shell": "^45.0.0-beta5",
+    "@girs/gobject-2.0": "^2.78.0-3.2.6",
+    "@girs/gtk-4.0": "^4.12.3-3.2.6",
+    "eslint": "^8.55.0",
+    "prettier": "^3.1.0",
+    "typescript": "^5.3.2"
   }
 }

--- a/quake-mode@repsac-by.github.com/extension.js
+++ b/quake-mode@repsac-by.github.com/extension.js
@@ -1,157 +1,184 @@
-'use strict';
-
-/* exported init, enable, disable */
-
-const { Meta, Shell } = imports.gi;
-const { main, altTab } = imports.ui;
-const { Workspace } = imports.ui.workspace;
-const { _isOverviewWindow } = Workspace.prototype;
-const { getWindows } = altTab;
-
-const { getSettings, getCurrentExtension } = imports.misc.extensionUtils;
-const Me = getCurrentExtension();
-
-const { QuakeModeApp, state } = Me.imports.quakemodeapp;
-const { Indicator } = Me.imports.indicator;
+import Meta from "gi://Meta";
+import Shell from "gi://Shell";
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+import * as altTab from "resource:///org/gnome/shell/ui/altTab.js";
+import { Workspace } from "resource:///org/gnome/shell/ui/workspace.js";
+import {
+  Extension,
+  InjectionManager,
+} from "resource:///org/gnome/shell/extensions/extension.js";
+import { QuakeModeApp, state } from "./quakemodeapp.js";
+import { Indicator } from "./indicator.js";
 
 /** @type {InstanceType<typeof Indicator> | undefined} */
 let indicator;
 
-/** @type {ReturnType<typeof getSettings> | undefined} */
-let settings;
-
-const IndicatorName = 'Quake-mode';
+const IndicatorName = "Quake-mode";
 
 const APPS_COUNT = 5;
 
 /** @type Map<number, InstanceType<typeof QuakeModeApp>> */
 const apps = new Map();
 
-function init() {
-}
+const injectionManager = new InjectionManager();
 
-function enable() {
-	settings = getSettings();
+export default class QuakeModeExtension extends Extension {
+  enable() {
+    this._settings = this.getSettings();
 
-	setTray(settings.get_boolean('quake-mode-tray'));
-	settings.connect('changed::quake-mode-tray', (settings, key) => {
-		setTray(settings.get_boolean(key));
-	});
+    this._setTray(this._settings.get_boolean("quake-mode-tray"));
+    this._settings.connect("changed::quake-mode-tray", (settings, key) => {
+      this._setTray(settings.get_boolean(key));
+    });
 
-	setupOverview(settings.get_boolean('quake-mode-hide-from-overview'));
-	settings.connect('changed::quake-mode-hide-from-overview', (settings, key) => {
-		setupOverview(settings.get_boolean(key));
-	});
+    this._setupOverview(
+      this._settings.get_boolean("quake-mode-hide-from-overview"),
+    );
+    this._settings.connect(
+      "changed::quake-mode-hide-from-overview",
+      (settings, key) => {
+        this._setupOverview(settings.get_boolean(key));
+      },
+    );
 
-	if (settings.get_string('quake-mode-app')) {
-		settings.get_child('apps').set_string('app-1', settings.get_string('quake-mode-app'));
-		settings.reset('quake-mode-app');
-	}
+    if (this._settings.get_string("quake-mode-app")) {
+      this._settings
+        .get_child("apps")
+        .set_string("app-1", this._settings.get_string("quake-mode-app"));
+      this._settings.reset("quake-mode-app");
+    }
 
-	if (settings.get_strv('quake-mode-hotkey')[0]) {
-		settings.get_child('accelerators').set_strv('quake-mode-accelerator-1',  settings.get_strv('quake-mode-hotkey'));
-		settings.reset('quake-mode-hotkey');
-	}
+    if (this._settings.get_strv("quake-mode-hotkey")[0]) {
+      this._settings
+        .get_child("accelerators")
+        .set_strv(
+          "quake-mode-accelerator-1",
+          this._settings.get_strv("quake-mode-hotkey"),
+        );
+      this._settings.reset("quake-mode-hotkey");
+    }
 
-	for (let i = 1; i <= APPS_COUNT; i++) {
-		main.wm.addKeybinding(
-			`quake-mode-accelerator-${i}`,
-			settings.get_child('accelerators'),
-			Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
-			Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW | Shell.ActionMode.POPUP,
-			() => toggle(i),
-		);
-	}
+    for (let i = 1; i <= APPS_COUNT; i++) {
+      Main.wm.addKeybinding(
+        `quake-mode-accelerator-${i}`,
+        this._settings.get_child("accelerators"),
+        Meta.KeyBindingFlags.IGNORE_AUTOREPEAT,
+        Shell.ActionMode.NORMAL |
+          Shell.ActionMode.OVERVIEW |
+          Shell.ActionMode.POPUP,
+        () => this._toggle(i),
+      );
+    }
+  }
 
+  disable() {
+    for (let i = 1; i <= APPS_COUNT; i++) {
+      Main.wm.removeKeybinding(`quake-mode-accelerator-${i}`);
+    }
 
+    if (indicator) {
+      indicator.destroy();
+      indicator = undefined;
+    }
 
-}
+    if (Main.sessionMode.currentMode !== "unlock-dialog") {
+      apps.forEach((app) => app && app.destroy());
+      apps.clear();
+    }
 
-function disable() {
-	for (let i = 1; i <= APPS_COUNT; i++) {
-		main.wm.removeKeybinding(`quake-mode-accelerator-${i}`);
-	}
+    if (this._settings) {
+      this._settings.run_dispose();
+      this._settings = undefined;
+    }
 
-	if (indicator) {
-		indicator.destroy();
-		indicator = undefined;
-	}
+    this._setupOverview(false);
+  }
 
-	if (main.sessionMode.currentMode !== 'unlock-dialog') {
-		apps.forEach(app => app && app.destroy());
-		apps.clear();
-	}
+  /**
+   * @param {number} i
+   * @returns {string}
+   */
+  _app_id(i) {
+    if (!this._settings) throw new Error("The settings base are not defined");
+    //@ts-expect-error
+    return this._settings.get_child("apps").get_string(`app-${i}`);
+  }
 
-	if (settings) {
-		settings.run_dispose();
-		settings = undefined;
-	}
+  /**
+   * @param {number} i
+   */
+  async _toggle(i) {
+    try {
+      let app = apps.get(i);
+      if (!app || app.state === state.DEAD) {
+        app = new QuakeModeApp(this._app_id(i));
+        apps.set(i, app);
+      }
 
-	setupOverview(false);
-}
+      await app.toggle();
+    } catch (e) {
+      Main.notify("Quake-mode", e instanceof Error ? e.message : String(e));
+    }
+  }
 
-/**
- * @param {number} i
- */
-function app_id (i) {
-	if (!settings) throw new Error('The settings base are not defined');
-	return settings.get_child('apps').get_string(`app-${i}`);
-}
+  /**
+   * @param {boolean} [show]
+   */
+  _setTray(show) {
+    if (indicator) {
+      indicator.destroy();
+      indicator = undefined;
+    }
 
-/**
- * @param {number} i
- */
-async function toggle(i) {
-	try {
-		let app = apps.get(i);
-		if (!app || app.state === state.DEAD) {
-			app = new QuakeModeApp(app_id(i));
-			apps.set(i, app);
-		}
+    if (show) {
+      indicator = new Indicator({
+        IndicatorName,
+        toggle: () => this._toggle(1),
+      });
+      Main.panel.addToStatusArea(IndicatorName, indicator.panelButton);
+    }
+  }
 
-		await app.toggle();
-	} catch (e) {
-		main.notify('Quake-mode', e instanceof Error ? e.message : String(e));
-	}
-}
+  /**
+   * @param {boolean} [hide]
+   */
+  _setupOverview(hide) {
+    if (hide) {
+      /** @param {import('@girs/meta-13').Meta.Window} window */
+      const has = (window) =>
+        [...apps.values()].some((app) => app.win === window);
 
-/**
- * @param {boolean} [show]
- */
-function setTray(show) {
-	if (indicator) {
-		indicator.destroy();
-		indicator = undefined;
-	}
+      injectionManager.overrideMethod(
+        Workspace.prototype,
+        "_isOverviewWindow",
+        (_isOverviewWindow) =>
+          function (window, ...rest) {
+            const show = _isOverviewWindow.call(this, window, ...rest);
+            return show && !has(window);
+          },
+      );
 
-	if (show) {
-		indicator = new Indicator({ IndicatorName, toggle: () => toggle(1) });
-		main.panel.addToStatusArea(IndicatorName, indicator.panelButton);
-	}
-}
+      injectionManager.overrideMethod(
+        altTab.WindowSwitcherPopup.prototype,
+        "_getWindowList",
+        (_getWindowList) =>
+          function (...args) {
+            const windows = _getWindowList.call(this, ...args);
+            return windows.filter((window) => !has(window));
+          },
+      );
 
-/**
- * @param {boolean} [hide]
- */
-function setupOverview(hide) {
-	if (hide) {
-		/** @param {import('@gi-types/meta10').Window} window */
-		const has = window => [ ...apps.values() ].some(app => app.win === window);
-
-		/** @param {import('@gi-types/meta10').Window} window */
-		Workspace.prototype._isOverviewWindow = window => {
-			const show = _isOverviewWindow(window);
-			return show && !has(window);
-		};
-
-		/** @param {import('@gi-types/meta10').Workspace} workspace */
-		altTab.getWindows = workspace => {
-			/** @type {import('@gi-types/meta10').Window[]} */
-			const windows = getWindows(workspace);
-			return windows.filter(window => !has(window));
-		};
-	} else {
-		Workspace.prototype._isOverviewWindow = _isOverviewWindow;
-		altTab.getWindows = getWindows;
-	}
+      injectionManager.overrideMethod(
+        altTab.WindowCyclerPopup.prototype,
+        "_getWindows",
+        (_getWindows) =>
+          function (...args) {
+            const windows = _getWindows.call(this, ...args);
+            return windows.filter((window) => !has(window));
+          },
+      );
+    } else {
+      injectionManager.clear();
+    }
+  }
 }

--- a/quake-mode@repsac-by.github.com/metadata.json
+++ b/quake-mode@repsac-by.github.com/metadata.json
@@ -1,10 +1,10 @@
 {
-	"name": "quake-mode",
-	"description": "Drop-down mode for any application",
-	"uuid": "quake-mode@repsac-by.github.com",
-	"shell-version": ["41", "42", "43", "44"],
-	"version": 8,
-	"url": "https://github.com/repsac-by/gnome-shell-extension-quake-mode",
-	"settings-schema": "com.github.repsac-by.quake-mode",
-	"gettext-domain": "quake-mode@repsac-by.github.com"
+  "name": "quake-mode",
+  "description": "Drop-down mode for any application",
+  "uuid": "quake-mode@repsac-by.github.com",
+  "shell-version": ["45"],
+  "version": 10,
+  "url": "https://github.com/repsac-by/gnome-shell-extension-quake-mode",
+  "settings-schema": "com.github.repsac-by.quake-mode",
+  "gettext-domain": "quake-mode@repsac-by.github.com"
 }

--- a/quake-mode@repsac-by.github.com/prefs.js
+++ b/quake-mode@repsac-by.github.com/prefs.js
@@ -123,6 +123,26 @@ const QuakeModePrefsWidget = GObject.registerClass(
       this.attach(label(_("Height - %")), 0, ++r, 1, 1);
       this.attach(spinHeight, 1, r, 1, 1);
 
+      // Gap
+      const spinGap = new Gtk.SpinButton({
+        adjustment: new Gtk.Adjustment({
+          lower: 0,
+          upper: 1000,
+          step_increment: 1,
+          page_increment: 5,
+        }),
+      });
+
+      settings.bind(
+        "quake-mode-gap",
+        spinGap,
+        "value",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Gap")), 0, ++r, 1, 1);
+      this.attach(spinGap, 1, r, 1, 1);
+
       // Horizontal align
       {
         const key = "quake-mode-halign";

--- a/quake-mode@repsac-by.github.com/prefs.js
+++ b/quake-mode@repsac-by.github.com/prefs.js
@@ -1,365 +1,448 @@
-'use strict';
+import GObject from "gi://GObject";
+import Gio from "gi://Gio";
+import Gtk from "gi://Gtk";
+import {
+  ExtensionPreferences,
+  gettext as _,
+} from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
+import { getMonitors } from "./util.js";
 
-/* exported init, buildPrefsWidget */
+export default class QuakeModePreferences extends ExtensionPreferences {
+  getPreferencesWidget() {
+    const widget = new Notebook();
+    widget.show();
 
-const { GObject, Gio, Gtk } = imports.gi;
-
-const { getSettings, getCurrentExtension, initTranslations, gettext: _ } = imports.misc.extensionUtils;
-const Me = getCurrentExtension();
-
-const { getMonitors } = Me.imports.util;
-
-/** @type {ReturnType<typeof getSettings>} */
-let settings;
-
-function init() {
-	settings = getSettings();
-	initTranslations();
+    return widget;
+  }
 }
 
-const QuakeModePrefsWidget
-= GObject.registerClass(class QuakeModePrefsWidget extends Gtk.Grid {
-	/**
-	 * @param {any} [params]
-	 */
-	_init(params) {
-		super._init(params);
-		this.set_margin_top(10);
-		this.set_margin_bottom(10);
-		this.set_margin_start(10);
-		this.set_margin_end(10);
-		this.set_row_spacing(10);
-		this.set_column_spacing(10);
-		this.set_orientation(Gtk.Orientation.VERTICAL);
-
-		let r = -1;
-		/** @param {string} label */
-		const label = label => new Gtk.Label({ label: label, halign: Gtk.Align.END });
-
-		// Tray Icon
-		const switchTray = new Gtk.Switch({ halign: Gtk.Align.START });
-
-		settings.bind('quake-mode-tray', switchTray, 'state', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Icon')), 0, ++r, 1, 1);
-		this.attach(switchTray, 1, r, 1, 1);
-
-		// Minimize on Focus Out
-		const switchFocusOut = new Gtk.Switch({ halign: Gtk.Align.START });
-
-		settings.bind('quake-mode-focusout', switchFocusOut, 'state', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Minimize on focus out')), 0, ++r, 1, 1);
-		this.attach(switchFocusOut, 1, r, 1, 1);
-
-		// Hide from Overview
-		const hideFromOverview = new Gtk.Switch({ halign: Gtk.Align.START });
-
-		settings.bind('quake-mode-hide-from-overview', hideFromOverview, 'state', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Hide from Overview')), 0, ++r, 1, 1);
-		this.attach(hideFromOverview, 1, r, 1, 1);
-
-		// Always on top
-		const alwaysOnTop = new Gtk.Switch({ halign: Gtk.Align.START });
-
-		settings.bind('quake-mode-always-on-top', alwaysOnTop, 'state', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Always on Top')), 0, ++r, 1, 1);
-		this.attach(alwaysOnTop, 1, r, 1, 1);
-
-		// Width
-		const spinWidth = new Gtk.SpinButton();
-		spinWidth.set_range(0, 100);
-		spinWidth.set_increments(1, 2);
-
-		settings.bind('quake-mode-width', spinWidth, 'value', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Width - %')), 0, ++r, 1, 1);
-		this.attach(spinWidth, 1, r, 1, 1);
-
-		// Height
-		const spinHeight = new Gtk.SpinButton();
-		spinHeight.set_range(0, 100);
-		spinHeight.set_increments(1, 2);
-
-		settings.bind('quake-mode-height', spinHeight, 'value', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Height - %')), 0, ++r, 1, 1);
-		this.attach(spinHeight, 1, r, 1, 1);
-
-		// Horizontal align
-		{
-			const key = 'quake-mode-halign';
-			const items = [
-				{ label: _('Left'), value: 'left' },
-				{ label: _('Right'), value: 'right' },
-				{ label: _('Center'), value: 'center' },
-			];
-
-			const model = new Gtk.ListStore();
-			model.set_column_types([ GObject.TYPE_STRING, GObject.TYPE_STRING ]);
-
-			const widget = new Gtk.ComboBox({ model });
-			const renderer = new Gtk.CellRendererText();
-
-			widget.pack_start(renderer, true);
-			widget.add_attribute(renderer, 'text', 0);
-
-			const current = settings.get_string(key);
-
-			for (const { label, value } of items) {
-				const iter = model.append();
-				//@ts-expect-error
-				model.set(iter, [ 0, 1 ], [ label, value ]);
-				if (current === value) widget.set_active_iter(iter);
-			}
-
-			widget.connect('changed', widget => {
-				const [ ok, iter ] = widget.get_active_iter();
-				if (ok) {
-					const value = /** @type {string} */ (model.get_value(iter, 1));
-					settings.set_string(key, value);
-				}
-			});
-
-			this.attach(label(_('Horizontal align')), 0, ++r, 1, 1);
-			this.attach(widget, 1, r, 1, 1);
-		}
-
-		// Vertical align
-		{
-			const key = 'quake-mode-valign';
-			const items = [
-				{ label: _('Top'), value: 'top' },
-				{ label: _('Bottom'), value: 'bottom' },
-			];
-
-			const model = new Gtk.ListStore();
-			model.set_column_types([ GObject.TYPE_STRING, GObject.TYPE_STRING ]);
-
-			const widget = new Gtk.ComboBox({ model });
-			const renderer = new Gtk.CellRendererText();
-
-			widget.pack_start(renderer, true);
-			widget.add_attribute(renderer, 'text', 0);
-
-			const current = settings.get_string(key);
-
-			for (const { label, value } of items) {
-				const iter = model.append();
-				//@ts-expect-error
-				model.set(iter, [ 0, 1 ], [ label, value ]);
-				if (current === value) widget.set_active_iter(iter);
-			}
-
-			widget.connect('changed', widget => {
-				const [ ok, iter ] = widget.get_active_iter();
-				if (ok) {
-					const value = /** @type {string} */ (model.get_value(iter, 1));
-					settings.set_string(key, value);
-				}
-			});
-
-			this.attach(label(_('Vertical align')), 0, ++r, 1, 1);
-			this.attach(widget, 1, r, 1, 1);
-		}
-
-		// Monitor Number
-		const Columns = { LABEL: 0, VALUE: 1 };
-		const monitorModel = new Gtk.ListStore();
-		monitorModel.set_column_types([ GObject.TYPE_STRING, GObject.TYPE_INT ]);
-		const selectMonitor = new Gtk.ComboBox({ model: monitorModel });
-		const selectMonitorRenderer = new Gtk.CellRendererText();
-		selectMonitor.pack_start(selectMonitorRenderer, true);
-		selectMonitor.add_attribute(selectMonitorRenderer, 'text', 0);
-
-		const monitors = getMonitors();
-		let monitorCurrentlySelected;
-
-		for (const [ idx, monitor ] of monitors.entries()) {
-			const iter = monitorModel.append();
-
-			monitorModel.set(
-				//@ts-expect-error
-				iter,
-				[ Columns.LABEL, Columns.VALUE ],
-				[ `#${idx}: ${monitor.manufacturer} ${monitor.model}`, idx ]
-			);
-
-			if (idx === settings.get_int('quake-mode-monitor')) {
-				monitorCurrentlySelected = iter;
-			}
-		}
-
-		if (monitorCurrentlySelected !== undefined) {
-			selectMonitor.set_active_iter(monitorCurrentlySelected);
-		}
-
-		selectMonitor.connect('changed', () => {
-			const [ success, iter ] = selectMonitor.get_active_iter();
-
-			if (!success) {
-				return;
-			}
-
-			const value = /** @type {number} */ (monitorModel.get_value(iter, Columns.VALUE));
-			settings.set_int('quake-mode-monitor', value);
-		});
-
-		this.attach(label(_('Monitor')), 0, ++r, 1, 1);
-		this.attach(selectMonitor, 1, r, 1, 1);
-
-		// Time
-		const spinTime = new Gtk.SpinButton({ digits: 2 });
-		spinTime.set_range(0, 2);
-		spinTime.set_increments(0.01, 0.02);
-
-		settings.bind('quake-mode-animation-time', spinTime, 'value', Gio.SettingsBindFlags.DEFAULT);
-
-		this.attach(label(_('Animation time - s')), 0, ++r, 1, 1);
-		this.attach(spinTime, 1, r, 1, 1);
-	}
-});
-
-const AcceleratorsWidget
-= GObject.registerClass(class AcceleratorsWidget extends Gtk.TreeView {
-	/** @param {any} [params] */
-	_init(params) {
-		super._init(params);
-
-		const Columns = { action: 0, accel: 1, app_id: 2, i: 3 };
-
-		const model = this.model = Gtk.ListStore.new([
-			GObject.TYPE_STRING,
-			GObject.TYPE_STRING,
-			GObject.TYPE_STRING,
-			GObject.TYPE_INT,
-		]);
-
-		/** @type {(row: [any, string, number]) => void}} */
-		function add_row([ accelerator, app_id, i ]) {
-			model.set(model.append(), [ 0, 1, 2, 3 ], [ _('Toggle'), accelerator, app_id, i ]);
-		}
-
-		for (let i = 1; i <=5; i++) {
-			add_row([
-				settings.get_child('accelerators').get_strv(`quake-mode-accelerator-${i}`)[0] || '',
-				settings.get_child('apps').get_string(`app-${i}`),
-				i,
-			]);
-		}
-
-		const actions = {
-			column: new Gtk.TreeViewColumn({ title: _('Action'), expand: true }),
-			renderer: new Gtk.CellRendererText(),
-		};
-
-		const accels = {
-			column: new Gtk.TreeViewColumn({ title: _('Shortcut Key'), min_width: 100 }),
-			renderer: new Gtk.CellRendererAccel({ editable: true }),
-		};
-
-		const apps = {
-			column: new Gtk.TreeViewColumn({ title: _('Application'), min_width: 150 }),
-			renderer: new Gtk.CellRendererText({ editable: true }),
-		};
-
-		actions.column.pack_start(actions.renderer, true);
-		accels.column.pack_start(accels.renderer, true);
-		apps.column.pack_start(apps.renderer, true);
-
-		actions.column.set_cell_data_func(actions.renderer, (column, cell, model, iter) => {
-			// @ts-expect-error
-			cell.text = model.get_value(iter, Columns.action);
-		});
-
-		accels.column.set_cell_data_func(accels.renderer, (column, cell, model, iter) => {
-			const accelerator = /** @type {string}*/ (model.get_value(iter, Columns.accel));
-			// @ts-expect-error
-			[ , cell.accel_key, cell.accel_mods ] = Gtk.accelerator_parse(accelerator);
-		});
-
-		apps.column.set_cell_data_func(apps.renderer, (column, cell, model, iter) => {
-			const app_id = /** @type {string} */ (model.get_value(iter, Columns.app_id));
-			const app = app_id && Gio.DesktopAppInfo.new(app_id);
-			// @ts-expect-error
-			cell.text = app ? app.get_display_name() : '';
-		});
-
-		this.append_column(actions.column);
-		this.append_column(accels.column);
-		this.append_column(apps.column);
-
-		accels.renderer.connect('accel-edited', (renderer, path, accel_key, accel_mod) => {
-			const [ ok, iter ] = model.get_iter(Gtk.TreePath.new_from_string(path));
-			if (ok) {
-				const name = Gtk.accelerator_name(accel_key, accel_mod);
-				//@ts-expect-error
-				model.set(iter, [ Columns.accel ], [ name ]);
-
-				const i = model.get_value(iter, Columns.i);
-				settings.get_child('accelerators').set_strv(`quake-mode-accelerator-${i}`, [ name ]);
-			}
-		});
-
-		accels.renderer.connect('accel-cleared', (renderer, path) => {
-			const [ ok, iter ] = model.get_iter(Gtk.TreePath.new_from_string(path));
-			if (ok) {
-				//@ts-expect-error
-				model.set(iter, [ Columns.accel ], [ '' ]);
-				const i = model.get_value(iter, Columns.i);
-				settings.get_child('accelerators').reset(`quake-mode-accelerator-${i}`);
-			}
-		});
-
-		apps.renderer.connect('editing-started', (renderer, cell, path) => {
-			const dialog = new Gtk.AppChooserDialog({
-				destroy_with_parent: true,
-				modal: true,
-				//@ts-expect-error
-				transient_for: this.get_root(),
-			});
-
-			dialog.get_widget().set({ show_all: false, show_other: true });
-
-			dialog.connect('response', (dialog, response) => {
-				if (response === Gtk.ResponseType.OK) {
-					const [ ok, iter ] = model.get_iter(Gtk.TreePath.new_from_string(path));
-					if (!ok) return;
-
-					const app_info = dialog.get_app_info();
-					if (!app_info) return;
-
-					const app_id = app_info.get_id();
-					if (!app_id) return;
-
-					model.set_value(iter, Columns.app_id, app_id);
-
-					const i = model.get_value(iter, Columns.i);
-					settings.get_child('apps').set_string(`app-${i}`, app_id);
-				}
-				dialog.destroy();
-			});
-
-			dialog.show();
-		});
-	}
-});
-
-const Notebook
-= GObject.registerClass(class Notebook extends Gtk.Notebook {
-	/** @param {any} [params] */
-	_init(params) {
-		super._init(params);
-		this.append_page(new QuakeModePrefsWidget(), new Gtk.Label({ label: _('Main') }));
-		this.append_page(new AcceleratorsWidget(),   new Gtk.Label({ label: _('Accelerators') }));
-	}
-});
-
-function buildPrefsWidget() {
-	const widget = new Notebook();
-	widget.show();
-
-	return widget;
-}
+const QuakeModePrefsWidget = GObject.registerClass(
+  class QuakeModePrefsWidget extends Gtk.Grid {
+    /**
+     * @param {any} [params]
+     */
+    _init(params) {
+      super._init(params);
+      const extensionObject =
+        /** @type import('@girs/gnome-shell/extensions/extension').Extension */ (
+          ExtensionPreferences.lookupByURL(import.meta.url)
+        );
+      const settings = extensionObject.getSettings();
+      this.set_margin_top(10);
+      this.set_margin_bottom(10);
+      this.set_margin_start(10);
+      this.set_margin_end(10);
+      this.set_row_spacing(10);
+      this.set_column_spacing(10);
+      this.set_orientation(Gtk.Orientation.VERTICAL);
+
+      let r = -1;
+      /** @param {string} label */
+      const label = (label) =>
+        new Gtk.Label({ label: label, halign: Gtk.Align.END });
+
+      // Tray Icon
+      const switchTray = new Gtk.Switch({ halign: Gtk.Align.START });
+
+      settings.bind(
+        "quake-mode-tray",
+        switchTray,
+        "state",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Icon")), 0, ++r, 1, 1);
+      this.attach(switchTray, 1, r, 1, 1);
+
+      // Minimize on Focus Out
+      const switchFocusOut = new Gtk.Switch({ halign: Gtk.Align.START });
+
+      settings.bind(
+        "quake-mode-focusout",
+        switchFocusOut,
+        "state",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Minimize on focus out")), 0, ++r, 1, 1);
+      this.attach(switchFocusOut, 1, r, 1, 1);
+
+      // Hide from Overview
+      const hideFromOverview = new Gtk.Switch({ halign: Gtk.Align.START });
+
+      settings.bind(
+        "quake-mode-hide-from-overview",
+        hideFromOverview,
+        "state",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Hide from Overview")), 0, ++r, 1, 1);
+      this.attach(hideFromOverview, 1, r, 1, 1);
+
+      // Always on top
+      const alwaysOnTop = new Gtk.Switch({ halign: Gtk.Align.START });
+
+      settings.bind(
+        "quake-mode-always-on-top",
+        alwaysOnTop,
+        "state",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Always on Top")), 0, ++r, 1, 1);
+      this.attach(alwaysOnTop, 1, r, 1, 1);
+
+      // Width
+      const spinWidth = new Gtk.SpinButton();
+      spinWidth.set_range(0, 100);
+      spinWidth.set_increments(1, 2);
+
+      settings.bind(
+        "quake-mode-width",
+        spinWidth,
+        "value",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Width - %")), 0, ++r, 1, 1);
+      this.attach(spinWidth, 1, r, 1, 1);
+
+      // Height
+      const spinHeight = new Gtk.SpinButton();
+      spinHeight.set_range(0, 100);
+      spinHeight.set_increments(1, 2);
+
+      settings.bind(
+        "quake-mode-height",
+        spinHeight,
+        "value",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Height - %")), 0, ++r, 1, 1);
+      this.attach(spinHeight, 1, r, 1, 1);
+
+      // Horizontal align
+      {
+        const key = "quake-mode-halign";
+        const items = [
+          { label: _("Left"), value: "left" },
+          { label: _("Right"), value: "right" },
+          { label: _("Center"), value: "center" },
+        ];
+
+        const model = new Gtk.ListStore();
+        model.set_column_types([GObject.TYPE_STRING, GObject.TYPE_STRING]);
+
+        const widget = new Gtk.ComboBox({ model });
+        const renderer = new Gtk.CellRendererText();
+
+        widget.pack_start(renderer, true);
+        widget.add_attribute(renderer, "text", 0);
+
+        const current = settings.get_string(key);
+
+        for (const { label, value } of items) {
+          const iter = model.append();
+          model.set(iter, [0, 1], [label, value]);
+          if (current === value) widget.set_active_iter(iter);
+        }
+
+        widget.connect("changed", (widget) => {
+          const [ok, iter] = widget.get_active_iter();
+          if (ok) {
+            const value = /** @type {string} */ (model.get_value(iter, 1));
+            settings.set_string(key, value);
+          }
+        });
+
+        this.attach(label(_("Horizontal align")), 0, ++r, 1, 1);
+        this.attach(widget, 1, r, 1, 1);
+      }
+
+      // Vertical align
+      {
+        const key = "quake-mode-valign";
+        const items = [
+          { label: _("Top"), value: "top" },
+          { label: _("Bottom"), value: "bottom" },
+        ];
+
+        const model = new Gtk.ListStore();
+        model.set_column_types([GObject.TYPE_STRING, GObject.TYPE_STRING]);
+
+        const widget = new Gtk.ComboBox({ model });
+        const renderer = new Gtk.CellRendererText();
+
+        widget.pack_start(renderer, true);
+        widget.add_attribute(renderer, "text", 0);
+
+        const current = settings.get_string(key);
+
+        for (const { label, value } of items) {
+          const iter = model.append();
+          model.set(iter, [0, 1], [label, value]);
+          if (current === value) widget.set_active_iter(iter);
+        }
+
+        widget.connect("changed", (widget) => {
+          const [ok, iter] = widget.get_active_iter();
+          if (ok) {
+            const value = /** @type {string} */ (model.get_value(iter, 1));
+            settings.set_string(key, value);
+          }
+        });
+
+        this.attach(label(_("Vertical align")), 0, ++r, 1, 1);
+        this.attach(widget, 1, r, 1, 1);
+      }
+
+      // Monitor Number
+      const Columns = { LABEL: 0, VALUE: 1 };
+      const monitorModel = new Gtk.ListStore();
+      monitorModel.set_column_types([GObject.TYPE_STRING, GObject.TYPE_INT]);
+      const selectMonitor = new Gtk.ComboBox({ model: monitorModel });
+      const selectMonitorRenderer = new Gtk.CellRendererText();
+      selectMonitor.pack_start(selectMonitorRenderer, true);
+      selectMonitor.add_attribute(selectMonitorRenderer, "text", 0);
+
+      const monitors = getMonitors();
+      let monitorCurrentlySelected;
+
+      for (const [idx, monitor] of monitors.entries()) {
+        const iter = monitorModel.append();
+
+        monitorModel.set(
+          iter,
+          [Columns.LABEL, Columns.VALUE],
+          [`#${idx}: ${monitor.manufacturer} ${monitor.model}`, idx],
+        );
+
+        if (idx === settings.get_int("quake-mode-monitor")) {
+          monitorCurrentlySelected = iter;
+        }
+      }
+
+      if (monitorCurrentlySelected !== undefined) {
+        selectMonitor.set_active_iter(monitorCurrentlySelected);
+      }
+
+      selectMonitor.connect("changed", () => {
+        const [success, iter] = selectMonitor.get_active_iter();
+
+        if (!success) {
+          return;
+        }
+
+        const value = /** @type {number} */ (
+          monitorModel.get_value(iter, Columns.VALUE)
+        );
+        settings.set_int("quake-mode-monitor", value);
+      });
+
+      this.attach(label(_("Monitor")), 0, ++r, 1, 1);
+      this.attach(selectMonitor, 1, r, 1, 1);
+
+      // Time
+      const spinTime = new Gtk.SpinButton({ digits: 2 });
+      spinTime.set_range(0, 2);
+      spinTime.set_increments(0.01, 0.02);
+
+      settings.bind(
+        "quake-mode-animation-time",
+        spinTime,
+        "value",
+        Gio.SettingsBindFlags.DEFAULT,
+      );
+
+      this.attach(label(_("Animation time - s")), 0, ++r, 1, 1);
+      this.attach(spinTime, 1, r, 1, 1);
+    }
+  },
+);
+
+const AcceleratorsWidget = GObject.registerClass(
+  class AcceleratorsWidget extends Gtk.TreeView {
+    /** @param {any} [params] */
+    _init(params) {
+      super._init(params);
+
+      const extensionObject =
+        /** @type import('@girs/gnome-shell/extensions/extension').Extension */ (
+          ExtensionPreferences.lookupByURL(import.meta.url)
+        );
+      const settings = extensionObject.getSettings();
+
+      const Columns = { action: 0, accel: 1, app_id: 2, i: 3 };
+
+      const model = (this.model = Gtk.ListStore.new([
+        GObject.TYPE_STRING,
+        GObject.TYPE_STRING,
+        GObject.TYPE_STRING,
+        GObject.TYPE_INT,
+      ]));
+
+      /** @type {(row: [any, string, number]) => void}} */
+      function add_row([accelerator, app_id, i]) {
+        model.set(
+          model.append(),
+          [0, 1, 2, 3],
+          [_("Toggle"), accelerator, app_id, i],
+        );
+      }
+
+      for (let i = 1; i <= 5; i++) {
+        add_row([
+          settings
+            .get_child("accelerators")
+            .get_strv(`quake-mode-accelerator-${i}`)[0] || "",
+          //@ts-expect-error
+          settings.get_child("apps").get_string(`app-${i}`),
+          i,
+        ]);
+      }
+
+      const actions = {
+        column: new Gtk.TreeViewColumn({ title: _("Action"), expand: true }),
+        renderer: new Gtk.CellRendererText(),
+      };
+
+      const accels = {
+        column: new Gtk.TreeViewColumn({
+          title: _("Shortcut Key"),
+          min_width: 100,
+        }),
+        renderer: new Gtk.CellRendererAccel({ editable: true }),
+      };
+
+      const apps = {
+        column: new Gtk.TreeViewColumn({
+          title: _("Application"),
+          min_width: 150,
+        }),
+        renderer: new Gtk.CellRendererText({ editable: true }),
+      };
+
+      actions.column.pack_start(actions.renderer, true);
+      accels.column.pack_start(accels.renderer, true);
+      apps.column.pack_start(apps.renderer, true);
+
+      actions.column.set_cell_data_func(
+        actions.renderer,
+        (column, cell, model, iter) => {
+          //@ts-expect-error
+          cell.text = model.get_value(iter, Columns.action);
+        },
+      );
+
+      accels.column.set_cell_data_func(
+        accels.renderer,
+        (column, cell, model, iter) => {
+          const accelerator = /** @type {string}*/ (
+            model.get_value(iter, Columns.accel)
+          );
+          //@ts-expect-error
+          [, cell.accel_key, cell.accel_mods] =
+            Gtk.accelerator_parse(accelerator);
+        },
+      );
+
+      apps.column.set_cell_data_func(
+        apps.renderer,
+        (column, cell, model, iter) => {
+          const app_id = /** @type {string} */ (
+            model.get_value(iter, Columns.app_id)
+          );
+          const app = app_id && Gio.DesktopAppInfo.new(app_id);
+          //@ts-expect-error
+          cell.text = app ? app.get_display_name() : "";
+        },
+      );
+
+      this.append_column(actions.column);
+      this.append_column(accels.column);
+      this.append_column(apps.column);
+
+      accels.renderer.connect(
+        "accel-edited",
+        (renderer, path, accel_key, accel_mod) => {
+          const [ok, iter] = model.get_iter(Gtk.TreePath.new_from_string(path));
+          if (ok) {
+            const name = Gtk.accelerator_name(accel_key, accel_mod);
+            model.set(iter, [Columns.accel], [name]);
+
+            const i = model.get_value(iter, Columns.i);
+            settings
+              .get_child("accelerators")
+              //@ts-expect-error
+              .set_strv(`quake-mode-accelerator-${i}`, [name]);
+          }
+        },
+      );
+
+      accels.renderer.connect("accel-cleared", (renderer, path) => {
+        const [ok, iter] = model.get_iter(Gtk.TreePath.new_from_string(path));
+        if (ok) {
+          model.set(iter, [Columns.accel], [""]);
+          const i = model.get_value(iter, Columns.i);
+          settings
+            .get_child("accelerators")
+            .reset(`quake-mode-accelerator-${i}`);
+        }
+      });
+
+      apps.renderer.connect("editing-started", (renderer, cell, path) => {
+        const dialog = new Gtk.AppChooserDialog({
+          destroy_with_parent: true,
+          modal: true,
+          //@ts-expect-error
+          transient_for: this.get_root(),
+        });
+
+        //@ts-expect-error
+        dialog.get_widget().set({ show_all: false, show_other: true });
+
+        dialog.connect("response", (dialog, response) => {
+          if (response === Gtk.ResponseType.OK) {
+            const [ok, iter] = model.get_iter(
+              Gtk.TreePath.new_from_string(path),
+            );
+            if (!ok) return;
+
+            const app_info = dialog.get_app_info();
+            if (!app_info) return;
+
+            const app_id = app_info.get_id();
+            if (!app_id) return;
+
+            model.set_value(iter, Columns.app_id, app_id);
+
+            const i = model.get_value(iter, Columns.i);
+            settings.get_child("apps").set_string(`app-${i}`, app_id);
+          }
+          dialog.destroy();
+        });
+
+        dialog.show();
+      });
+    }
+  },
+);
+
+const Notebook = GObject.registerClass(
+  class Notebook extends Gtk.Notebook {
+    /** @param {any} [params] */
+    _init(params) {
+      super._init(params);
+      this.append_page(
+        new QuakeModePrefsWidget(),
+        new Gtk.Label({ label: _("Main") }),
+      );
+      this.append_page(
+        new AcceleratorsWidget(),
+        new Gtk.Label({ label: _("Accelerators") }),
+      );
+    }
+  },
+);

--- a/quake-mode@repsac-by.github.com/quakemodeapp.js
+++ b/quake-mode@repsac-by.github.com/quakemodeapp.js
@@ -43,6 +43,7 @@ export var QuakeModeApp = class {
 
     settings.connect("changed::quake-mode-width", place);
     settings.connect("changed::quake-mode-height", place);
+    settings.connect("changed::quake-mode-gap", place);
     settings.connect("changed::quake-mode-halign", place);
     settings.connect("changed::quake-mode-valign", place);
     settings.connect("changed::quake-mode-monitor", place);
@@ -92,6 +93,10 @@ export var QuakeModeApp = class {
     return this.settings.get_int("quake-mode-height");
   }
 
+  get gap() {
+    return this.settings.get_int("quake-mode-gap");
+  }
+
   get focusout() {
     return this.settings.get_boolean("quake-mode-focusout");
   }
@@ -105,7 +110,9 @@ export var QuakeModeApp = class {
   }
 
   get halign() {
-    return this.settings.get_enum("quake-mode-halign");
+    return /** @type {"left" | "center" | "right"} */ (
+      this.settings.get_string("quake-mode-halign")
+    );
   }
 
   get valign() {
@@ -265,15 +272,20 @@ export var QuakeModeApp = class {
   }
 
   place() {
-    const { win, width, height, halign, valign, monitor } = this;
+    const { win, width, height, gap, halign, valign, monitor } = this;
 
     if (!win) return;
 
     const area = win.get_work_area_for_monitor(monitor),
       w = Math.round((width * area.width) / 100),
       h = Math.round((height * area.height) / 100),
-      x = area.x + Math.round(halign && (area.width - w) / halign),
-      y = area.y + (valign === "top" ? 0 : area.height - height);
+      x =
+        area.x +
+        Math.round(
+          (area.width - w) * { left: 0, center: 0.5, right: 1 }[halign] +
+            { left: gap, center: 0, right: -gap }[halign],
+        ),
+      y = area.y + (valign === "top" ? gap : area.height - h - gap);
 
     win.move_to_monitor(monitor);
     win.move_resize_frame(false, x, y, w, h);

--- a/quake-mode@repsac-by.github.com/quakemodeapp.js
+++ b/quake-mode@repsac-by.github.com/quakemodeapp.js
@@ -1,308 +1,293 @@
-'use strict';
+import Clutter from "gi://Clutter";
+import GLib from "gi://GLib";
+import Shell from "gi://Shell";
+import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
+import * as Main from "resource:///org/gnome/shell/ui/main.js";
+import { on, once } from "./util.js";
 
-/* exported QuakeModeApp, state */
-/**
- * @typedef {{
- *     QuakeModeApp: typeof QuakeModeApp;
- *     state: typeof state;
- * }} types
- */
-
-const { Clutter, GLib, Shell } = imports.gi;
-
-const Main = imports.ui.main;
-
-const { getSettings, getCurrentExtension } = imports.misc.extensionUtils;
-const Me = getCurrentExtension();
-const { on, once } = Me.imports.util;
-
-var state = {
-	INITIAL:  Symbol('INITIAL'),
-	READY:    Symbol('READY'),
-	STARTING: Symbol('STARTING'),
-	RUNNING:  Symbol('RUNNING'),
-	DEAD:     Symbol('DEAD'),
+export var state = {
+  INITIAL: Symbol("INITIAL"),
+  READY: Symbol("READY"),
+  STARTING: Symbol("STARTING"),
+  RUNNING: Symbol("RUNNING"),
+  DEAD: Symbol("DEAD"),
 };
 
-var QuakeModeApp = class {
-	/**
-	 * @param {string} app_id
-	 */
-	constructor(app_id) {
-		this.isTransition = false;
-		this.state = state.INITIAL;
+export var QuakeModeApp = class {
+  /**
+   * @param {string} app_id
+   */
+  constructor(app_id) {
+    this.isTransition = false;
+    this.state = state.INITIAL;
+
+    /** @type {import('@girs/meta-13').Meta.Window?} */
+    this.win = null;
+
+    /** @type {import('@girs/shell-13').Shell.App?} */
+    this.app = Shell.AppSystem.get_default().lookup_app(app_id);
+
+    if (!this.app) {
+      this.state = state.DEAD;
+      throw new Error(`application '${app_id}' not found`);
+    }
+
+    const place = () => this.place();
+    const setupAlwaysOnTop = () => this.setupAlwaysOnTop(this.alwaysOnTop);
+
+    const extensionObject =
+      /** @type import('@girs/gnome-shell/extensions/extension').Extension */ (
+        Extension.lookupByURL(import.meta.url)
+      );
+    const settings = (this.settings = extensionObject.getSettings());
+
+    settings.connect("changed::quake-mode-width", place);
+    settings.connect("changed::quake-mode-height", place);
+    settings.connect("changed::quake-mode-halign", place);
+    settings.connect("changed::quake-mode-valign", place);
+    settings.connect("changed::quake-mode-monitor", place);
+    settings.connect("changed::quake-mode-always-on-top", setupAlwaysOnTop);
 
-		/** @type {import('@gi-types/meta10').Window?} */
-		this.win = null;
+    this.state = state.READY;
+  }
+
+  destroy() {
+    this.state = state.DEAD;
 
-		/** @type {import('@gi-types/shell0').App?} */
-		this.app = Shell.AppSystem.get_default().lookup_app(app_id);
+    if (this.settings) {
+      this.settings.run_dispose();
+    }
 
-		if (!this.app) {
-			this.state = state.DEAD;
-			throw new Error(`application '${app_id}' not found`);
-		}
+    this.win = null;
+    this.app = null;
+  }
 
-		const place = () => this.place();
-		const setupAlwaysOnTop = () => this.setupAlwaysOnTop(this.alwaysOnTop);
+  get actor() {
+    if (!this.win) return null;
 
+    /** @type {import('@girs/meta-13').Meta.WindowActor} */
+    //@ts-expect-error Incorrect return type? TODO: investigate
+    const actor = this.win.get_compositor_private();
 
-		const settings = this.settings = getSettings();
+    if (!actor) return null;
 
-		settings.connect('changed::quake-mode-width',   place);
-		settings.connect('changed::quake-mode-height',  place);
-		settings.connect('changed::quake-mode-halign',  place);
-		settings.connect('changed::quake-mode-valign',  place);
-		settings.connect('changed::quake-mode-monitor', place);
-		settings.connect('changed::quake-mode-always-on-top', setupAlwaysOnTop);
+    return "clip_y" in actor
+      ? actor
+      : Object.defineProperty(actor, "clip_y", {
+          get() {
+            return this.clip_rect.origin.y;
+          },
+          set(y) {
+            const rect = this.clip_rect;
+            this.set_clip(rect.origin.x, y, rect.size.width, rect.size.height);
+          },
+        });
+  }
 
-		this.state = state.READY;
-	}
+  get width() {
+    return this.settings.get_int("quake-mode-width");
+  }
 
-	destroy() {
-		this.state = state.DEAD;
+  get height() {
+    return this.settings.get_int("quake-mode-height");
+  }
 
-		if (this.settings) {
-			this.settings.run_dispose();
-		}
+  get focusout() {
+    return this.settings.get_boolean("quake-mode-focusout");
+  }
 
-		this.win = null;
-		this.app = null;
-	}
+  get ainmation_time() {
+    return this.settings.get_double("quake-mode-animation-time") * 1000;
+  }
 
-	get actor() {
-		if (! this.win)
-			return null;
+  get alwaysOnTop() {
+    return this.settings.get_boolean("quake-mode-always-on-top");
+  }
 
-		/** @type {import('@gi-types/meta10').WindowActor} */
-		const actor = this.win.get_compositor_private();
+  get halign() {
+    return this.settings.get_enum("quake-mode-halign");
+  }
 
-		if (! actor)
-			return null;
+  get valign() {
+    return this.settings.get_string("quake-mode-valign");
+  }
 
-		return 'clip_y' in actor
-			? actor
-			: Object.defineProperty(actor, 'clip_y', {
-				get()  { return this.clip_rect.origin.y; },
-				set(y) {
-					const rect = this.clip_rect;
-					this.set_clip(
-						rect.origin.x,	 y,
-						rect.size.width, rect.size.height
-					);
-				}
-			});
-	}
+  get monitor() {
+    const { win, settings } = this;
 
-	get width()  { return this.settings.get_int('quake-mode-width'); }
+    const monitor = settings.get_int("quake-mode-monitor");
 
-	get height() { return this.settings.get_int('quake-mode-height'); }
+    if (!win) return monitor;
 
-	get focusout() { return this.settings.get_boolean('quake-mode-focusout'); }
+    if (monitor < 0) return 0;
 
-	get ainmation_time() { return this.settings.get_double('quake-mode-animation-time') * 1000; }
+    const max = global.display.get_n_monitors() - 1;
+    if (monitor > max) return max;
 
-	get alwaysOnTop () { return this.settings.get_boolean('quake-mode-always-on-top'); }
+    return monitor;
+  }
 
-	get halign () { return this.settings.get_enum('quake-mode-halign'); }
+  toggle() {
+    const { win } = this;
 
-	get valign() { return this.settings.get_string('quake-mode-valign'); }
+    if (this.state === state.READY)
+      return this.launch()
+        .then(() => this.first_place())
+        .catch((e) => {
+          this.destroy();
+          throw e;
+        });
 
-	get monitor() {
-		const { win, settings } = this;
+    if (this.state !== state.RUNNING || !win) return;
 
-		const monitor = settings.get_int('quake-mode-monitor');
+    if (win.has_focus()) return this.hide();
 
-		if (!win)
-			return monitor;
+    if (win.is_hidden()) return this.show();
 
-		if (monitor < 0)
-			return 0;
+    Main.activateWindow(win);
+  }
 
-		const max = global.display.get_n_monitors() - 1;
-		if (monitor > max)
-			return max;
+  launch() {
+    const { app } = this;
+    this.state = state.STARTING;
 
-		return monitor;
-	}
+    if (!app) return Promise.reject(new Error("no app"));
 
-	toggle() {
-		const { win } = this;
+    app.open_new_window(-1);
 
-		if (this.state === state.READY)
-			return this.launch()
-				.then(() => this.first_place())
-				.catch(e => {
-					this.destroy();
-					throw e;
-				});
+    return new Promise((resolve, reject) => {
+      const timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5000, () => {
+        sig.off();
+        reject(new Error(`launch '${app.id}' timeout`));
+        return true;
+      });
 
-		if (this.state !== state.RUNNING || !win)
-			return;
+      const sig = once(app, "windows-changed", () => {
+        GLib.source_remove(timer);
 
-		if (win.has_focus())
-			return this.hide();
+        if (app.get_n_windows() < 1)
+          return reject(`app '${app.id}' is launched but no windows`);
 
-		if (win.is_hidden())
-			return this.show();
+        this.win = app.get_windows()[0];
 
-		Main.activateWindow(win);
-	}
+        this.setupAlwaysOnTop(this.alwaysOnTop);
 
-	launch() {
-		const { app } = this;
-		this.state = state.STARTING;
+        once(this.win, "unmanaged", () => this.destroy());
 
-		if (!app)
-			return Promise.reject(new Error('no app'));
+        resolve(true);
+      });
+    });
+  }
 
-		app.open_new_window(-1);
+  first_place() {
+    const { win, actor } = this;
 
-		return new Promise((resolve, reject) => {
-			const timer = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 5000, () => {
-				sig.off();
-				reject(new Error(`launch '${app.id}' timeout`));
-				return true;
-			});
+    if (!win || !actor) return;
 
-			const sig = once(app, 'windows-changed', () => {
-				GLib.source_remove(timer);
+    actor.set_clip(0, 0, actor.width, 0);
+    win.stick();
 
-				if (app.get_n_windows() < 1)
-					return reject(`app '${app.id}' is launched but no windows`);
+    on(global.window_manager, "map", (sig, wm, metaWindowActor) => {
+      if (metaWindowActor !== actor) return;
 
-				this.win = app.get_windows()[0];
+      sig.off();
+      wm.emit("kill-window-effects", actor);
 
-				this.setupAlwaysOnTop(this.alwaysOnTop);
+      once(win, "size-changed", () => {
+        this.state = state.RUNNING;
+        actor.remove_clip();
+        this.show();
+      });
 
-				once(this.win, 'unmanaged', () => this.destroy());
+      this.place();
+    });
+  }
 
-				resolve(true);
-			});
-		});
-	}
+  show() {
+    const { actor, focusout, valign } = this;
 
-	first_place() {
-		const { win, actor } = this;
+    if (this.state !== state.RUNNING) return;
 
-		if (!win || !actor)
-			return;
+    if (this.isTransition) return;
 
-		actor.set_clip(0, 0, actor.width, 0);
-		win.stick();
+    if (!actor) return;
 
-		on(global.window_manager, 'map', (sig, wm, metaWindowActor) => {
-			if (metaWindowActor !== actor)
-				return;
+    const parent = actor.get_parent();
+    if (!parent) return;
 
-			sig.off();
-			wm.emit('kill-window-effects', actor);
+    this.isTransition = true;
 
-			once(win, 'size-changed', () => {
-				this.state = state.RUNNING;
-				actor.remove_clip();
-				this.show();
-			});
+    parent.set_child_above_sibling(actor, null);
+    (actor.translation_y = actor.height * (valign === "top" ? -1 : 2)),
+      //@ts-expect-error Missing type. TODO: contribute to @girs
+      Main.wm.skipNextEffect(actor);
+    Main.activateWindow(actor.meta_window);
 
-			this.place();
-		});
-	}
-
-	show() {
-		const { actor, focusout, valign } = this;
-
-		if (this.state !== state.RUNNING)
-			return;
-
-		if (this.isTransition)
-			return;
-
-		if (!actor)
-			return;
-
-		const parent = actor.get_parent();
-		if (!parent)
-			return;
-
-		this.isTransition = true;
-
-		parent.set_child_above_sibling(actor, null);
-		actor.translation_y = actor.height * (valign === 'top' ? -1 : 2),
-		Main.wm.skipNextEffect(actor);
-		Main.activateWindow(actor.meta_window);
-
-		//@ts-expect-error
-		actor.ease({
-			translation_y: 0,
-			duration: this.ainmation_time,
-			mode: Clutter.AnimationMode.EASE_OUT_QUART,
-			onComplete: () => {
-				this.isTransition = false;
-				if (focusout)
-					once(global.display, 'notify::focus-window', () => this.hide());
-			},
-		});
-
-		this.place();
-	}
-
-	hide() {
-		const { actor, valign } = this;
-
-		if (!actor)
-			return;
-
-		if (this.state !== state.RUNNING)
-			return;
-
-		if (this.isTransition)
-			return;
-
-		this.isTransition = true;
-
-		//@ts-expect-error
-		actor.ease({
-			translation_y: actor.height * (valign === 'top' ? -1 : 2),
-			duration: this.ainmation_time,
-			mode: Clutter.AnimationMode.EASE_IN_QUART,
-			onComplete: () => {
-				Main.wm.skipNextEffect(actor);
-				actor.meta_window.minimize();
-				actor.translation_y = 0;
-				this.isTransition = false;
-			},
-		});
-	}
-
-	place() {
-		const { win, width, height, halign, valign, monitor } = this;
-
-		if (!win)
-			return;
-
-		const
-			area = win.get_work_area_for_monitor(monitor),
-			w = Math.round(width * area.width / 100),
-			h = Math.round(height * area.height / 100),
-			x = area.x + Math.round(halign && (area.width - w) / halign),
-			y = area.y + (valign === 'top' ? 0 : area.height - height);
-
-		win.move_to_monitor(monitor);
-		win.move_resize_frame(false, x, y, w, h);
-	}
-
-	/**
-	 * @param {boolean} [above]
-	 */
-	setupAlwaysOnTop(above) {
-		const { win } = this;
-
-		if (!win)
-			return;
-
-		if (above)
-			win.make_above();
-		else
-			win.unmake_above();
-	}
+    //@ts-expect-error Missing type? TODO: investigate
+    actor.ease({
+      translation_y: 0,
+      duration: this.ainmation_time,
+      mode: Clutter.AnimationMode.EASE_OUT_QUART,
+      onComplete: () => {
+        this.isTransition = false;
+        if (focusout)
+          once(global.display, "notify::focus-window", () => this.hide());
+      },
+    });
+
+    this.place();
+  }
+
+  hide() {
+    const { actor, valign } = this;
+
+    if (!actor) return;
+
+    if (this.state !== state.RUNNING) return;
+
+    if (this.isTransition) return;
+
+    this.isTransition = true;
+
+    //@ts-expect-error
+    actor.ease({
+      translation_y: actor.height * (valign === "top" ? -1 : 2),
+      duration: this.ainmation_time,
+      mode: Clutter.AnimationMode.EASE_IN_QUART,
+      onComplete: () => {
+        //@ts-expect-error
+        Main.wm.skipNextEffect(actor);
+        actor.meta_window.minimize();
+        actor.translation_y = 0;
+        this.isTransition = false;
+      },
+    });
+  }
+
+  place() {
+    const { win, width, height, halign, valign, monitor } = this;
+
+    if (!win) return;
+
+    const area = win.get_work_area_for_monitor(monitor),
+      w = Math.round((width * area.width) / 100),
+      h = Math.round((height * area.height) / 100),
+      x = area.x + Math.round(halign && (area.width - w) / halign),
+      y = area.y + (valign === "top" ? 0 : area.height - height);
+
+    win.move_to_monitor(monitor);
+    win.move_resize_frame(false, x, y, w, h);
+  }
+
+  /**
+   * @param {boolean} [above]
+   */
+  setupAlwaysOnTop(above) {
+    const { win } = this;
+
+    if (!win) return;
+
+    if (above) win.make_above();
+    else win.unmake_above();
+  }
 };

--- a/quake-mode@repsac-by.github.com/schemas/com.github.repsac-by.quake-mode.gschema.xml
+++ b/quake-mode@repsac-by.github.com/schemas/com.github.repsac-by.quake-mode.gschema.xml
@@ -55,6 +55,11 @@
 			<default>46</default>
 		</key>
 
+		<key name="quake-mode-gap" type="i">
+			<range min="0"/>
+			<default>10</default>
+		</key>
+
 		<key name="quake-mode-animation-time" type="d">
 			<range min="0.1" max="2"/>
 			<default>0.25</default>

--- a/quake-mode@repsac-by.github.com/util.js
+++ b/quake-mode@repsac-by.github.com/util.js
@@ -1,75 +1,61 @@
-'use strict';
-
-/* exported on, once, getMonitors */
-/**
- *  @typedef {{
- *     on: typeof on;
- *     once: typeof once;
- *     getMonitors: typeof getMonitors;
- * }} types
- */
-
-const Gdk = imports.gi.Gdk;
+import Gdk from "gi://Gdk";
 
 class Signal {
-	/**
-	 * @param {import('@gi-types/gobject2').Object} target
-	 * @param {string} name
-	 * @param {(self: Signal, ...args: any[]) => void} cb
-	 */
-	constructor(target, name, cb) {
-		this.name = name;
-		this.target = target;
-
-		this.id = target.connect(name, (...args) => cb(this, ...args));
-	}
-	off() {
-		this.target.disconnect(this.id);
-	}
+  /**
+   * @param {import('@girs/gobject-2.0').GObject.Object} target
+   * @param {string} name
+   * @param {(self: Signal, ...args: any[]) => void} cb
+   */
+  constructor(target, name, cb) {
+    this.name = name;
+    this.target = target;
+    this.id = target.connect(name, (...args) => cb(this, ...args));
+  }
+  off() {
+    this.target.disconnect(this.id);
+  }
 }
 
 /**
- * @param {import('@gi-types/gobject2').Object} target
+ * @param {import('@girs/gobject-2.0').GObject.Object} target
  * @param {string} signal_name
  * @param {(self: Signal, ...args: any[]) => void} cb
  */
-function on(target, signal_name, cb) {
-	return new Signal(target, signal_name, cb);
+export function on(target, signal_name, cb) {
+  return new Signal(target, signal_name, cb);
 }
 
 /**
- * @param {import('@gi-types/gobject2').Object} target
+ * @param {import('@girs/gobject-2.0').GObject.Object} target
  * @param {string} signal_name
  * @param {( ...args: any ) => void} cb
-*/
-function once(target, signal_name, cb) {
-	let disconnected = false;
-	return new Signal(target, signal_name, (signal, ...args) => {
-		if (disconnected)	return;
-		disconnected = true;
-		signal.off();
-		cb(...args);
-	});
+ */
+export function once(target, signal_name, cb) {
+  let disconnected = false;
+  return new Signal(target, signal_name, (signal, ...args) => {
+    if (disconnected) return;
+    disconnected = true;
+    signal.off();
+    cb(...args);
+  });
 }
 
-function getMonitors() {
-	const monitors = [];
+export function getMonitors() {
+  const monitors = [];
 
-	const display = Gdk.Display.get_default();
-	if (display && 'get_monitors' in display) { // GDK4.4+
-		const monitorsAvailable = display.get_monitors();
-		for (let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
-			const monitor = /** @type {import('@gi-types/gdk4').Monitor} */ (monitorsAvailable.get_item(idx));
-			monitors.push(monitor);
-		}
-	} else if (display && 'get_n_monitors' in display) { // GDK3.24
-		for (let idx = 0; idx < display.get_n_monitors(); idx++) {
-			const monitor = /** @type {import('@gi-types/gdk3').Monitor} */ (display.get_monitor(idx));
-			monitors.push(monitor);
-		}
-	} else {
-		log(`Could not get monitor list from Display of type ${display}`);
-	}
+  const display = Gdk.Display.get_default();
+  if (display && "get_monitors" in display) {
+    // GDK4.4+
+    const monitorsAvailable = display.get_monitors();
+    for (let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
+      const monitor = /** @type {import('@girs/gdk-4.0').Gdk.Monitor} */ (
+        monitorsAvailable.get_item(idx)
+      );
+      monitors.push(monitor);
+    }
+  } else {
+    log(`Could not get monitor list from Display of type ${display}`);
+  }
 
-	return monitors;
+  return monitors;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,12 @@
 {
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"strict": true,
-		"downlevelIteration": true,
-		"noEmit": true,
-		"module": "Node16",
-		"skipLibCheck": true,
-		"lib": [
-			"ES2020",
-		],
-		"types": [
-			"@gi-types/gjs-environment",
-		],
-	},
-
-	"exclude": [
-		"node_modules/**/*"
-	]
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "types": ["@girs/gjs", "@girs/gnome-shell/ambient"]
+  }
 }


### PR DESCRIPTION
Closes #75
- Commit package-lock.json, gitignore node_modules
package-lock.json is intended to be committed to ensure node_modules reproducibility
- Port to GNOME 45
- Use [InjectionManager](https://gjs.guide/extensions/topics/extension.html#injectionmanager)
- Update dependencies
- Switch from `@gi-types` to `@girs`
`@girs` ([ts-for-gir](https://github.com/gjsify/ts-for-gir)) is actively developed and also offers [hand-written type definitions](https://github.com/gjsify/gnome-shell) for GNOME Shell extensions specifically. I wrote some myself in index.d.ts and have yet to contribute them upstream.
- Simplify ESLint config by regenerating it with `npm init @eslint/config` and format code using Prettier
This is an opinionated change, but Prettier is pretty standard in JS nowadays and it helps maintaining a very consistent code style a lot.
- Add gap setting