### PR TITLE
Fix packaging issue

### DIFF
--- a/quake-mode@repsac-by.github.com/po/tr.po
+++ b/quake-mode@repsac-by.github.com/po/tr.po
@@ -13,7 +13,7 @@ msgstr ""
 "Last-Translator: Muhammed Taha <mtaha1905@yandex.com>\n"
 "Language: Turkish \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: quake-mode@repsac-by.github.com/prefs.js:44


### PR DESCRIPTION
Set the charset in the Turkish translation to UTF-8. Previously had a placeholder. 

Fixes https://github.com/repsac-by/gnome-shell-extension-quake-mode/issues/77