### PR TITLE
Extension not loading on Ubuntu 24.04 LTS - Gnome 46

### DIFF
--- a/quake-mode@repsac-by.github.com/metadata.json
+++ b/quake-mode@repsac-by.github.com/metadata.json
@@ -2,7 +2,7 @@
   "name": "quake-mode",
   "description": "Drop-down mode for any application",
   "uuid": "quake-mode@repsac-by.github.com",
-  "shell-version": ["45"],
+  "shell-version": ["46"],
   "version": 10,
   "url": "https://github.com/repsac-by/gnome-shell-extension-quake-mode",
   "settings-schema": "com.github.repsac-by.quake-mode",


### PR DESCRIPTION
The extension doesn't load on Ubuntu 24.04 LTS - Gnome 46 due to incompatible versions.

This fixes that.