### PR TITLE
feat: :tada: Support for Gnome 48

### DIFF
--- a/quake-mode@repsac-by.github.com/metadata.json
+++ b/quake-mode@repsac-by.github.com/metadata.json
@@ -2,7 +2,7 @@
   "name": "quake-mode",
   "description": "Drop-down mode for any application",
   "uuid": "quake-mode@repsac-by.github.com",
-  "shell-version": ["45", "46", "47"],
+  "shell-version": ["45", "46", "47", "48"],
   "version": 10,
   "url": "https://github.com/repsac-by/gnome-shell-extension-quake-mode",
   "settings-schema": "com.github.repsac-by.quake-mode",


### PR DESCRIPTION
This extension works out of the box on Gnome 48